### PR TITLE
Update from API level 28 to 29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # --------------------------------------------------------------------
 # Docker parameters
 # --------------------------------------------------------------------
-DOCKER_IMG_VER := 20200527
+DOCKER_IMG_VER := 20200924
 DOCKER_IMG := yacgroup/yacguide-build:$(DOCKER_IMG_VER)
 DOCKER_CONTAINER := yacguide-build
 DOCKER_MOUNT_TARGET := /mnt/yacguide-build

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 // Create this file with some default values because otherwise the Gradle build fails.
 if (!keystorePropertiesFile.exists()) {
     keystorePropertiesFile.text = """\
-// These are just some default values. 
+// These are just some default values.
 storePassword=yacguide
 keyPassword=yacguide_key
 keyAlias=key0
@@ -40,11 +40,11 @@ play {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     defaultConfig {
         applicationId "com.yacgroup.yacguide"
         minSdkVersion 22
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode androidGitVersion.code()
         versionName androidGitVersion.name()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -98,8 +98,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:design:28.0.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
+    implementation 'com.android.support.constraint:constraint-layout:2.0.1'
+    testImplementation 'junit:junit:4.13'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
 
     def room_version = "2.2.5"
@@ -121,10 +121,10 @@ dependencies {
     testImplementation "androidx.room:room-testing:$room_version"
 
     implementation 'net.sf.kxml:kxml2:2.3.0'
-    implementation 'com.caverock:androidsvg:1.3'
+    implementation 'com.caverock:androidsvg:1.4'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "io.noties.markwon:core:4.3.1"
+    implementation 'io.noties.markwon:core:4.6.0'
 }
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.60'
+    ext.kotlin_version = '1.4.10'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 


### PR DESCRIPTION
The following tools/modules are bumped to a higher version:
  * Gradle: 3.6.3 -> 4.0.1
  * Kotlin: 1.3.60 -> 1.4.10
  * com.android.support.constraint:constraint-layout: 1.1.3 -> 2.0.1
  * junit:junit: 4.12 -> 4.13
  * com.caverock:androidsvg: 1.3 -> 1.4
  * io.noties.markwon:core: 4.3.1 -> 4.6.0