### PR TITLE
Display progress for sector update

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/UpdatableTableActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/UpdatableTableActivity.kt
@@ -46,7 +46,7 @@ abstract class UpdatableTableActivity : TableActivity(), UpdateListener {
     }
 
     // UpdateListener
-    override fun onEvent(success: Boolean) {
+    override fun onUpdateFinished(success: Boolean) {
         _updateDialog?.dismiss()
 
         if (success) {
@@ -55,6 +55,12 @@ abstract class UpdatableTableActivity : TableActivity(), UpdateListener {
             Toast.makeText(this, R.string.error_on_refresh, Toast.LENGTH_SHORT).show()
         }
         displayContent()
+    }
+
+    override fun onUpdateStatus(statusMessage: String) {
+        runOnUiThread {
+            _updateDialog?.findViewById<TextView>(R.id.dialogText)?.text = statusMessage
+        }
     }
 
     fun update(v: View = View(this)) {

--- a/app/src/main/java/com/yacgroup/yacguide/UpdateListener.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/UpdateListener.kt
@@ -19,5 +19,6 @@ package com.yacgroup.yacguide
 
 interface UpdateListener {
 
-    fun onEvent(success: Boolean)
+    fun onUpdateStatus(statusMessage: String)
+    fun onUpdateFinished(success: Boolean)
 }

--- a/app/src/main/java/com/yacgroup/yacguide/network/CountryParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/CountryParser.kt
@@ -23,15 +23,18 @@ import com.yacgroup.yacguide.database.DatabaseWrapper
 
 import org.json.JSONArray
 import org.json.JSONException
+import java.util.*
 
 class CountryParser(private val _db: DatabaseWrapper, listener: UpdateListener) : JSONWebParser(listener) {
 
     private val _countries = mutableListOf<Country>()
 
-    init {
-        networkRequests.add(NetworkRequest(
-                NetworkRequestUId(RequestType.COUNTRY_DATA, 0),
-                "${baseUrl}jsonland.php?app=yacguide"))
+    override fun initNetworkRequests() {
+        networkRequests = LinkedList(listOf(
+                NetworkRequest(
+                    NetworkRequestUId(RequestType.COUNTRY_DATA, 0),
+                    "${baseUrl}jsonland.php?app=yacguide")
+        ))
     }
 
     @Throws(JSONException::class)

--- a/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
@@ -55,6 +55,7 @@ abstract class JSONWebParser(private var _listener: UpdateListener): NetworkList
 
     fun fetchData() {
         _processedRequestsCount = 0
+        initNetworkRequests()
         for (request in networkRequests) {
             NetworkTask(request.requestId, this).execute(request.url)
         }
@@ -63,7 +64,10 @@ abstract class JSONWebParser(private var _listener: UpdateListener): NetworkList
     @Throws(JSONException::class)
     protected abstract fun parseData(requestId: NetworkRequestUId, json: String)
 
+    protected abstract fun initNetworkRequests()
+
+    // NetworkListener
     protected open fun onFinalTaskResolved() {
-        _listener.onEvent(_success)
+        _listener.onUpdateFinished(_success)
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/network/RegionParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/RegionParser.kt
@@ -25,6 +25,7 @@ import com.yacgroup.yacguide.utils.ParserUtils
 
 import org.json.JSONArray
 import org.json.JSONException
+import java.util.*
 
 class RegionParser(
         private val _db: DatabaseWrapper,
@@ -34,10 +35,12 @@ class RegionParser(
 
     private val _regions = mutableListOf<Region>()
 
-    init {
-        networkRequests.add(NetworkRequest(
-                NetworkRequestUId(RequestType.REGION_DATA, 0),
-                "${baseUrl}jsongebiet.php?app=yacguide&land=${NetworkUtils.encodeString2Url(_countryName)}"))
+    override fun initNetworkRequests() {
+        networkRequests = LinkedList(listOf(
+                NetworkRequest(
+                    NetworkRequestUId(RequestType.REGION_DATA, 0),
+                    "${baseUrl}jsongebiet.php?app=yacguide&land=${NetworkUtils.encodeString2Url(_countryName)}")
+        ))
     }
 
     @Throws(JSONException::class)


### PR DESCRIPTION
Resolves #106.

This also fixes a small bug: If updating a region multiple times without leaving the corresponding activity in between, rock-, route- and comment- data will be downloaded twice the 2nd time, triple the 3rd time etc. - However, this was fixed by introducing an `initNetworkRequests()` method.