### PR TITLE
Improve error message in case of a tourbook import error

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/TourbookActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/TourbookActivity.kt
@@ -18,7 +18,7 @@
 package com.yacgroup.yacguide
 
 import android.app.Activity
-import android.app.Dialog
+import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
@@ -113,28 +113,26 @@ class TourbookActivity : BaseNavigationActivity() {
     }
 
     private fun _import(uri: Uri) {
-        val confirmDialog = Dialog(this)
-        confirmDialog.setContentView(R.layout.dialog)
-        confirmDialog.findViewById<TextView>(R.id.dialogText).text = getString(
-                R.string.override_tourbook)
-        confirmDialog.findViewById<View>(R.id.yesButton).setOnClickListener {
-            try {
-                TourbookExporter(_db, contentResolver).importTourbook(uri)
-                Toast.makeText(this, getString(R.string.tourbook_import_successfull),
-                        Toast.LENGTH_SHORT).show()
-            } catch (e: Exception) {
-                Toast.makeText(this, getString(R.string.tourbook_import_error),
-                        Toast.LENGTH_SHORT).show()
+        val confirmDialog = AlertDialog.Builder(this).apply {
+            setTitle(R.string.warning)
+            setMessage(getString(R.string.override_tourbook))
+            setIcon(android.R.drawable.ic_dialog_alert)
+            setNegativeButton(R.string.cancel) { dialog, _ -> dialog.dismiss()}
+            setPositiveButton(R.string.ok) { dialog, _ ->
+                try {
+                    TourbookExporter(_db, contentResolver).importTourbook(uri)
+                    _makeToast(getString(R.string.tourbook_import_successfull))
+                } catch (e: Exception) {
+                    _makeToast(getString(R.string.tourbook_import_error))
+                }
+                _initYears()
             }
-            _initYears()
-            confirmDialog.dismiss()
         }
-        confirmDialog.findViewById<View>(R.id.noButton).setOnClickListener {
-            confirmDialog.dismiss()
-        }
-        confirmDialog.setCanceledOnTouchOutside(false)
-        confirmDialog.setCancelable(false)
         confirmDialog.show()
+    }
+
+    private fun _makeToast(msg: String) {
+        Toast.makeText(this, msg, Toast.LENGTH_SHORT).show()
     }
 
     private fun _export(uri: Uri) {

--- a/app/src/main/java/com/yacgroup/yacguide/TourbookActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/TourbookActivity.kt
@@ -39,6 +39,8 @@ import com.yacgroup.yacguide.utils.IntentConstants
 import com.yacgroup.yacguide.utils.ParserUtils
 import com.yacgroup.yacguide.utils.WidgetUtils
 
+import org.json.JSONException
+
 import java.io.IOException
 
 import java.util.Arrays
@@ -122,13 +124,35 @@ class TourbookActivity : BaseNavigationActivity() {
                 try {
                     TourbookExporter(_db, contentResolver).importTourbook(uri)
                     _makeToast(getString(R.string.tourbook_import_successfull))
-                } catch (e: Exception) {
-                    _makeToast(getString(R.string.tourbook_import_error))
+                } catch (e: JSONException) {
+                    // Show only the first part of the detailed error message because
+                    // the whole JSON string is contained.
+                    _showImportError(e.message.toString(), 200)
+                } catch (e: IOException) {
+                    // Show the full message because at the moment it is not clear
+                    // how the message looks like.
+                    _showImportError(e.message.toString())
                 }
                 _initYears()
             }
         }
         confirmDialog.show()
+    }
+
+    // Show dialog with given message. Optionally, limit the number of characters to show.
+    private fun _showImportError(errMsg: String, maxCharsShow: Int? = null) {
+        val dialog = AlertDialog.Builder(this).apply {
+            setTitle(R.string.tourbook_import_error)
+            if (maxCharsShow == null) {
+                setMessage(errMsg)
+            } else {
+                setMessage(errMsg.take(maxCharsShow)
+                        + if (errMsg.length > maxCharsShow) " ..." else "")
+            }
+            setIcon(android.R.drawable.ic_dialog_alert)
+            setPositiveButton(R.string.ok) { dialog, _ -> dialog.dismiss() }
+        }
+        dialog.show()
     }
 
     private fun _makeToast(msg: String) {

--- a/app/src/main/java/com/yacgroup/yacguide/database/TourbookExporter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/TourbookExporter.kt
@@ -50,8 +50,8 @@ class TourbookExporter(
 
     @Throws(IOException::class)
     private fun _writeStrToUri(uri: Uri, str: String) {
-        _contentResolver.openFileDescriptor(uri, "w")?.use {
-            FileOutputStream(it.fileDescriptor).use {
+        _contentResolver.openFileDescriptor(uri, "w")?.use { fileDescriptor ->
+            FileOutputStream(fileDescriptor.fileDescriptor).use {
                 it.write(str.toByteArray(Charsets.UTF_8))
             }
         }
@@ -80,12 +80,13 @@ class TourbookExporter(
 
     @Throws(JSONException::class)
     private fun ascend2Json(ascend: Ascend): JSONObject {
-        val jsonAscend = JSONObject()
-        jsonAscend.put(_routeIdKey, ascend.routeId.toString())
-        jsonAscend.put(_styleIdKey, ascend.styleId.toString())
-        jsonAscend.put(_yearKey, ascend.year.toString())
-        jsonAscend.put(_monthKey, ascend.month.toString())
-        jsonAscend.put(_dayKey, ascend.day.toString())
+        val jsonAscend = JSONObject().apply {
+            put(_routeIdKey, ascend.routeId.toString())
+            put(_styleIdKey, ascend.styleId.toString())
+            put(_yearKey, ascend.year.toString())
+            put(_monthKey, ascend.month.toString())
+            put(_dayKey, ascend.day.toString())
+        }
         val partnerList = JSONArray()
         _db.getPartnerNames(ascend.partnerIds.orEmpty()).map { partnerList.put(it) }
         jsonAscend.put(_partnersKey, partnerList)
@@ -105,15 +106,15 @@ class TourbookExporter(
         var partnerId = 1
         for (i in 0 until jsonAscends.length()) {
             val jsonAscend = jsonAscends.getJSONObject(i)
-            val routeId = ParserUtils.jsonField2Int(jsonAscend, _routeIdKey)
-            val ascend = Ascend()
-            ascend.id = ascendId++
-            ascend.routeId = routeId
-            ascend.styleId = ParserUtils.jsonField2Int(jsonAscend, _styleIdKey)
-            ascend.year = ParserUtils.jsonField2Int(jsonAscend, _yearKey)
-            ascend.month = ParserUtils.jsonField2Int(jsonAscend, _monthKey)
-            ascend.day = ParserUtils.jsonField2Int(jsonAscend, _dayKey)
-            ascend.notes = jsonAscend.getString(_notesKey)
+            val ascend = Ascend().apply {
+                id = ascendId++
+                routeId = ParserUtils.jsonField2Int(jsonAscend, _routeIdKey)
+                styleId = ParserUtils.jsonField2Int(jsonAscend, _styleIdKey)
+                year = ParserUtils.jsonField2Int(jsonAscend, _yearKey)
+                month = ParserUtils.jsonField2Int(jsonAscend, _monthKey)
+                day = ParserUtils.jsonField2Int(jsonAscend, _dayKey)
+                notes = jsonAscend.getString(_notesKey)
+            }
             val partnerNames = jsonAscend.getJSONArray(_partnersKey)
             val partnerIds = ArrayList<Int>()
             for (j in 0 until partnerNames.length()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="cancel">Abbrechen</string>
     <string name="more">Mehr</string>
     <string name="warning">Warnung</string>
+    <string name="error">Fehler</string>
 
     <!-- Menu -->
     <string name="menu_database">Datenbank</string>
@@ -114,7 +115,7 @@
     <string name="override_tourbook">Dies überschreibt das gesamte Tourenbuch.</string>
     <string name="tourbook_export_successfull">Tourenbuch erfolgreich exportiert</string>
     <string name="tourbook_import_successfull">Tourenbuch erfolgreich importiert</string>
-    <string name="tourbook_import_error">Fehler beim Import des Tourenbuchs</string>
+    <string name="tourbook_import_error">Fehler beim Import</string>
     <string name="tourbook_export_error">Fehler beim Export des Tourenbuchs</string>
 
     <!-- Ascend edit -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="ok">OK</string>
     <string name="cancel">Abbrechen</string>
     <string name="more">Mehr</string>
+    <string name="warning">Warnung</string>
 
     <!-- Menu -->
     <string name="menu_database">Datenbank</string>
@@ -110,8 +111,7 @@
     <string name="project_text_symbol">Projekte \u2117</string>
 
     <!-- Tourbook IO -->
-    <string name="override_tourbook">Dies überschreibt das gesamte Tourenbuch.
-                                     Trotzdem importieren?</string>
+    <string name="override_tourbook">Dies überschreibt das gesamte Tourenbuch.</string>
     <string name="tourbook_export_successfull">Tourenbuch erfolgreich exportiert</string>
     <string name="tourbook_import_successfull">Tourenbuch erfolgreich importiert</string>
     <string name="tourbook_import_error">Fehler beim Import des Tourenbuchs</string>


### PR DESCRIPTION
Fixes #208 

@paetz: What do you say about this solution?

If there is e.g. a syntax issue in the JSON file, the error message looks e.g. like `Unterminated object at character 42 of <JSON string>`. It would be possible to parse this message, cut only the characters around the mentioned position and so show the exact issue. However, I think this may a bit too over-engineered at this point. Additionally the code may break in case the message changes in the future.