### PR TITLE
Show corresponding routes on project or botch filtering

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/ClimbingObject.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/ClimbingObject.kt
@@ -28,12 +28,8 @@ enum class ClimbingObjectLevel(val value: Int) {
     eRoute(4);
 
     companion object {
-        fun fromInt(value: Int) = ClimbingObjectLevel.values().first { it.value == value }
+        fun fromInt(value: Int) = values().first { it.value == value }
     }
 }
 
-class ClimbingObject(level: ClimbingObjectLevel, parentId: Int, parentName: String) {
-    val level: ClimbingObjectLevel = level
-    val parentId: Int = parentId
-    val parentName: String = parentName
-}
+class ClimbingObject(val level: ClimbingObjectLevel, val parentId: Int, val parentName: String)

--- a/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
@@ -37,15 +37,11 @@ class RockActivity : TableActivityWithOptionsMenu() {
     private var _onlyOfficialSummits: Boolean = false
     private var _rockNamePart: String = ""
     private var _filterName: String = ""
-    private var _filterProjects: Boolean = false
-    private var _filterBotches: Boolean = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         _filterName = intent.getStringExtra(IntentConstants.FILTER_NAME).orEmpty()
-        _filterProjects = intent.getBooleanExtra(IntentConstants.FILTER_PROJECTS, false)
-        _filterBotches = intent.getBooleanExtra(IntentConstants.FILTER_BOTCHES, false)
 
         properties = arrayListOf(RockSearchable(this), AscentFilterable(this))
 
@@ -141,6 +137,9 @@ class RockActivity : TableActivityWithOptionsMenu() {
             )
             layout.addView(WidgetUtils.createHorizontalLine(this, 1))
         }
+        if (rocks.isEmpty()) {
+            Toast.makeText(this, R.string.no_rocks_available, Toast.LENGTH_SHORT).show()
+        }
     }
 
     override fun onStop() {
@@ -150,26 +149,10 @@ class RockActivity : TableActivityWithOptionsMenu() {
 
     private fun _getAndFilterRocks(): List<Rock> {
         val rocks = when (activityLevel.level) {
-            ClimbingObjectLevel.eCountry -> {
-                if (_filterProjects) db.getProjectedRocks()
-                else if (_filterBotches) db.getBotchedRocks()
-                else db.getRocks()
-            }
-            ClimbingObjectLevel.eRegion -> {
-                if (_filterProjects) db.getProjectedRocksForCountry(activityLevel.parentName)
-                else if (_filterBotches) db.getBotchedRocksForCountry(activityLevel.parentName)
-                else db.getRocksForCountry(activityLevel.parentName)
-            }
-            ClimbingObjectLevel.eSector -> {
-                if (_filterProjects) db.getProjectedRocksForRegion(activityLevel.parentId)
-                else if (_filterBotches) db.getBotchedRocksForRegion(activityLevel.parentId)
-                else db.getRocksForRegion(activityLevel.parentId)
-            }
-            ClimbingObjectLevel.eRock -> {
-                if (_filterProjects) db.getProjectedRocksForSector(activityLevel.parentId)
-                else if (_filterBotches) db.getBotchedRocksForSector(activityLevel.parentId)
-                else db.getRocksForSector(activityLevel.parentId)
-            }
+            ClimbingObjectLevel.eCountry -> db.getRocks()
+            ClimbingObjectLevel.eRegion -> db.getRocksForCountry(activityLevel.parentName)
+            ClimbingObjectLevel.eSector -> db.getRocksForRegion(activityLevel.parentId)
+            ClimbingObjectLevel.eRock -> db.getRocksForSector(activityLevel.parentId)
             else -> emptyList()
         }
         return if (_filterName.isNotEmpty())
@@ -184,12 +167,12 @@ class RockActivity : TableActivityWithOptionsMenu() {
             val sector = db.getSector(rock.parentId)!!
             if (activityLevel.level.value < ClimbingObjectLevel.eSector.value) {
                 val region = db.getRegion(sector.parentId)!!
-                sectorInfo = "${region.name} ${getString(R.string.arrow)} "
+                sectorInfo = "${region.name} ${getString(R.string.right_arrow)} "
             }
             val sectorNames = ParserUtils.decodeObjectNames(sector.name)
             sectorInfo += sectorNames.first
             if (sectorNames.second.isNotEmpty()) {
-                sectorInfo += " / " + sectorNames.second
+                sectorInfo += " / ${sectorNames.second}"
             }
         }
         return sectorInfo

--- a/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
@@ -137,9 +137,6 @@ class RockActivity : TableActivityWithOptionsMenu() {
             )
             layout.addView(WidgetUtils.createHorizontalLine(this, 1))
         }
-        if (rocks.isEmpty()) {
-            Toast.makeText(this, R.string.no_rocks_available, Toast.LENGTH_SHORT).show()
-        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
@@ -151,9 +151,6 @@ class RouteActivity : TableActivity() {
                     typeface = typeface))
             layout.addView(WidgetUtils.createHorizontalLine(this, 1))
         }
-        if (routes.isEmpty()) {
-            Toast.makeText(this, R.string.no_routes_available, Toast.LENGTH_SHORT).show()
-        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
@@ -26,7 +26,6 @@ import android.os.Bundle
 import android.view.View
 import android.widget.*
 
-import com.yacgroup.yacguide.database.DatabaseWrapper
 import com.yacgroup.yacguide.database.Rock
 import com.yacgroup.yacguide.database.Route
 import com.yacgroup.yacguide.utils.IntentConstants
@@ -36,30 +35,18 @@ import com.yacgroup.yacguide.utils.WidgetUtils
 
 class RouteActivity : TableActivity() {
 
-    private lateinit var _rock: Rock
     private lateinit var _searchBarHandler: SearchBarHandler
     private var _onlyOfficialRoutes: Boolean = false
     private var _routeNamePart: String = ""
+    private var _filterProjects: Boolean = false
+    private var _filterBotches: Boolean = false
+    private var _rock: Rock? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        _rock = db.getRock(activityLevel.parentId)!!
-
-        val rockStatus = when (_rock.status){
-            Rock.statusCollapsed -> getString(R.string.rock_collapsed)
-            Rock.statusProhibited -> getString(R.string.rock_fully_prohibited)
-            Rock.statusTemporarilyProhibited -> getString(R.string.rock_temporarily_prohibited)
-            Rock.statusPartlyProhibited -> getString(R.string.rock_partly_prohibited)
-            else -> {
-                if (_rock.type == Rock.typeUnofficial) {
-                    getString(R.string.rock_inofficial)
-                } else {
-                    ""
-                }
-            }
-        }
-        findViewById<TextView>(R.id.infoTextView).text = rockStatus
+        _filterProjects = intent.getBooleanExtra(IntentConstants.FILTER_PROJECTS, false)
+        _filterBotches = intent.getBooleanExtra(IntentConstants.FILTER_BOTCHES, false)
 
         _searchBarHandler = SearchBarHandler(
             findViewById(R.id.searchBarLayout),
@@ -68,6 +55,12 @@ class RouteActivity : TableActivity() {
             resources.getBoolean(R.bool.only_official_routes),
             customSettings
         ) { routeNamePart, onlyOfficialRoutes -> _onSearchBarUpdate(routeNamePart, onlyOfficialRoutes) }
+
+        if (activityLevel.level == ClimbingObjectLevel.eRoute) {
+            _rock = db.getRock(activityLevel.parentId)
+        } else {
+            findViewById<ImageButton>(R.id.mapButton).visibility = View.INVISIBLE
+        }
     }
 
     override fun getLayoutId() = R.layout.activity_route
@@ -76,7 +69,7 @@ class RouteActivity : TableActivity() {
     fun showMap(v: View) {
         try {
             val intent = Intent(Intent.ACTION_VIEW).apply {
-                data = Uri.parse("geo:${_rock.latitude},${_rock.longitude}")
+                data = Uri.parse("geo:${_rock?.latitude},${_rock?.longitude}")
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK
             }
             startActivity(intent)
@@ -86,28 +79,36 @@ class RouteActivity : TableActivity() {
     }
 
     override fun showComments(v: View) {
-        showRockComments(_rock.id)
+        when (activityLevel.level) {
+            ClimbingObjectLevel.eSector -> showRegionComments(activityLevel.parentId)
+            ClimbingObjectLevel.eRock -> showSectorComments(activityLevel.parentId)
+            ClimbingObjectLevel.eRoute -> showRockComments(activityLevel.parentId)
+            else -> showNoCommentToast()
+        }
     }
 
     override fun displayContent() {
         val layout = findViewById<LinearLayout>(R.id.tableLayout)
         layout.removeAllViews()
-        val rockName = ParserUtils.decodeObjectNames(_rock.name)
-        this.title = if (rockName.first.isNotEmpty()) rockName.first else rockName.second
 
-        var routes = db.getRoutes(_rock.id)
+        val levelName = ParserUtils.decodeObjectNames(activityLevel.parentName)
+        this.title = if (levelName.first.isNotEmpty()) levelName.first else levelName.second
+        _displayRockInfo(findViewById(R.id.infoTextView))
+
+        var routes = _getAndFilterRoutes()
+        // additional searchbar filters:
         if (_onlyOfficialRoutes) {
             routes = routes.filter { _isOfficialRoute(it) }
+        }
+        if (_routeNamePart.isNotEmpty()) {
+            routes = routes.filter{ it.name.orEmpty().lowercase().contains(_routeNamePart.lowercase()) }
         }
 
         for (route in routes) {
             val routeName = ParserUtils.decodeObjectNames(route.name)
-            if (_routeNamePart.isNotEmpty() && routeName.toList().none{ it.lowercase().contains(_routeNamePart.lowercase()) }) {
-                continue
-            }
             val commentCount = db.getRouteCommentCount(route.id)
             val commentCountAdd = if (commentCount > 0) "   [$commentCount]" else ""
-            val onCLickListener = View.OnClickListener {
+            val onClickListener = View.OnClickListener {
                 val intent = Intent(this@RouteActivity, DescriptionActivity::class.java)
                 intent.putExtra(IntentConstants.CLIMBING_OBJECT_PARENT_ID, route.id)
                 intent.putExtra(IntentConstants.CLIMBING_OBJECT_PARENT_NAME, route.name)
@@ -122,25 +123,109 @@ class RouteActivity : TableActivity() {
             }
             bgColor = colorizeEntry(route.ascendsBitMask, bgColor)
             val decorationAdd = decorateEntry(route.ascendsBitMask)
+
+            val sectorInfo = _getSectorInfo(route)
+            if (sectorInfo.isNotEmpty()) {
+                layout.addView(
+                    WidgetUtils.createCommonRowLayout(
+                        this,
+                        textLeft = sectorInfo,
+                        textSizeDp = WidgetUtils.textFontSizeDp,
+                        onClickListener = onClickListener,
+                        bgColor = bgColor,
+                        typeface = Typeface.NORMAL
+                    )
+                )
+            }
             layout.addView(WidgetUtils.createCommonRowLayout(this,
                     textLeft = "${routeName.first}$commentCountAdd$decorationAdd",
                     textRight = route.grade.orEmpty(),
-                    onClickListener = onCLickListener,
+                    onClickListener = onClickListener,
                     bgColor = bgColor,
                     typeface = typeface))
             layout.addView(WidgetUtils.createCommonRowLayout(this,
                     textLeft = routeName.second,
                     textSizeDp = WidgetUtils.textFontSizeDp,
-                    onClickListener = onCLickListener,
+                    onClickListener = onClickListener,
                     bgColor = bgColor,
                     typeface = typeface))
             layout.addView(WidgetUtils.createHorizontalLine(this, 1))
+        }
+        if (routes.isEmpty()) {
+            Toast.makeText(this, R.string.no_routes_available, Toast.LENGTH_SHORT).show()
         }
     }
 
     override fun onStop() {
         _searchBarHandler.storeCustomSettings(getString(R.string.only_official_routes))
         super.onStop()
+    }
+
+    private fun _getAndFilterRoutes(): List<Route> = when (activityLevel.level) {
+        ClimbingObjectLevel.eCountry -> {
+            if (_filterProjects) db.getProjectedRoutes()
+            else if (_filterBotches) db.getBotchedRoutes()
+            else db.getRoutes()
+        }
+        ClimbingObjectLevel.eRegion -> {
+            if (_filterProjects) db.getProjectedRoutesForCountry(activityLevel.parentName)
+            else if (_filterBotches) db.getBotchedRoutesForCountry(activityLevel.parentName)
+            else db.getRoutesForCountry(activityLevel.parentName)
+        }
+        ClimbingObjectLevel.eSector -> {
+            if (_filterProjects) db.getProjectedRoutesForRegion(activityLevel.parentId)
+            else if (_filterBotches) db.getBotchedRoutesForRegion(activityLevel.parentId)
+            else db.getRoutesForRegion(activityLevel.parentId)
+        }
+        ClimbingObjectLevel.eRock -> {
+            if (_filterProjects) db.getProjectedRoutesForSector(activityLevel.parentId)
+            else if (_filterBotches) db.getBotchedRoutesForSector(activityLevel.parentId)
+            else db.getRoutesForSector(activityLevel.parentId)
+        }
+        ClimbingObjectLevel.eRoute -> {
+            if (_filterProjects) db.getProjectedRoutesForRock(activityLevel.parentId)
+            else if (_filterBotches) db.getBotchedRoutesForRock(activityLevel.parentId)
+            else db.getRoutesForRock(activityLevel.parentId)
+        }
+        else -> emptyList()
+    }
+
+    private fun _getSectorInfo(route: Route): String {
+        val arrow = getString(R.string.right_arrow)
+        var sectorInfo = ""
+        if (activityLevel.level.value < ClimbingObjectLevel.eRoute.value) {
+            val rock = db.getRock(route.parentId)!!
+            if (activityLevel.level.value < ClimbingObjectLevel.eRock.value) {
+                val sector = db.getSector(rock.parentId)!!
+                if (activityLevel.level.value < ClimbingObjectLevel.eSector.value) {
+                    val region = db.getRegion(sector.parentId)!!
+                    sectorInfo = "${region.name} $arrow "
+                }
+                val sectorNames = ParserUtils.decodeObjectNames(sector.name)
+                val altName = if (sectorNames.second.isNotEmpty()) " / ${sectorNames.second}" else ""
+                sectorInfo += "${sectorNames.first} $altName $arrow "
+            }
+            val rockNames = ParserUtils.decodeObjectNames(rock.name)
+            val altName = if (rockNames.second.isNotEmpty()) " / ${rockNames.second}" else ""
+            sectorInfo += "${rockNames.first} $altName"
+        }
+        return sectorInfo
+    }
+
+    private fun _displayRockInfo(infoTextView: TextView) {
+        infoTextView.text = when (_rock?.status){
+            Rock.statusCollapsed -> getString(R.string.rock_collapsed)
+            Rock.statusProhibited -> getString(R.string.rock_fully_prohibited)
+            Rock.statusTemporarilyProhibited -> getString(R.string.rock_temporarily_prohibited)
+            Rock.statusPartlyProhibited -> getString(R.string.rock_partly_prohibited)
+            else -> {
+                if (_rock?.type == Rock.typeUnofficial) {
+                    getString(R.string.rock_inofficial)
+                } else {
+                    ""
+                }
+            }
+        }
     }
 
     private fun _onSearchBarUpdate(routeNamePart: String, onlyOfficialRoutes: Boolean) {

--- a/app/src/main/java/com/yacgroup/yacguide/activity_properties/AscentFilterable.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/activity_properties/AscentFilterable.kt
@@ -19,7 +19,7 @@ package com.yacgroup.yacguide.activity_properties
 
 import android.content.Intent
 import com.yacgroup.yacguide.R
-import com.yacgroup.yacguide.RockActivity
+import com.yacgroup.yacguide.RouteActivity
 import com.yacgroup.yacguide.TableActivityWithOptionsMenu
 import com.yacgroup.yacguide.utils.IntentConstants
 
@@ -29,13 +29,13 @@ class AscentFilterable(private val _activity: TableActivityWithOptionsMenu) : Ac
 
     override fun onMenuAction(menuItemId: Int) {
         when (menuItemId) {
-            R.id.action_filter_projects -> _goToFilteredRocksView(IntentConstants.FILTER_PROJECTS)
-            R.id.action_filter_botches -> _goToFilteredRocksView(IntentConstants.FILTER_BOTCHES)
+            R.id.action_filter_projects -> _goToFilteredRoutesView(IntentConstants.FILTER_PROJECTS)
+            R.id.action_filter_botches -> _goToFilteredRoutesView(IntentConstants.FILTER_BOTCHES)
         }
     }
 
-    private fun _goToFilteredRocksView(filterIntent: String) {
-        val intent = Intent(_activity, RockActivity::class.java)
+    private fun _goToFilteredRoutesView(filterIntent: String) {
+        val intent = Intent(_activity, RouteActivity::class.java)
         intent.putExtra(IntentConstants.CLIMBING_OBJECT_LEVEL, _activity.activityLevel.level.value)
         intent.putExtra(IntentConstants.CLIMBING_OBJECT_PARENT_ID, _activity.activityLevel.parentId)
         intent.putExtra(IntentConstants.CLIMBING_OBJECT_PARENT_NAME, _activity.activityLevel.parentName)

--- a/app/src/main/java/com/yacgroup/yacguide/database/DatabaseWrapper.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/DatabaseWrapper.kt
@@ -58,37 +58,45 @@ class DatabaseWrapper(context: Context) {
 
     fun getRocksForSector(sectorId: Int) = _db.rockDao().getAllInSector(sectorId)
 
-    fun getProjectedRocksForSector(sectorId: Int) = _db.rockDao().getAllInSectorForStyle(sectorId, AscendStyle.ePROJECT.id)
-
-    fun getBotchedRocksForSector(sectorId: Int) = _db.rockDao().getAllInSectorForStyle(sectorId, AscendStyle.eBOTCHED.id)
-
     fun getRocksForRegion(regionId: Int) = _db.rockDao().getAllInRegion(regionId)
-
-    fun getProjectedRocksForRegion(regionId: Int) = _db.rockDao().getAllInRegionForStyle(regionId, AscendStyle.ePROJECT.id)
-
-    fun getBotchedRocksForRegion(regionId: Int) = _db.rockDao().getAllInRegionForStyle(regionId, AscendStyle.eBOTCHED.id)
 
     fun getRocksForCountry(countryName: String) = _db.rockDao().getAllInCountry(countryName)
 
-    fun getProjectedRocksForCountry(countryName: String) = _db.rockDao().getAllInCountryForStyle(countryName, AscendStyle.ePROJECT.id)
-
-    fun getBotchedRocksForCountry(countryName: String) = _db.rockDao().getAllInCountryForStyle(countryName, AscendStyle.eBOTCHED.id)
-
     fun getRocks() = _db.rockDao().all
-
-    fun getProjectedRocks() = _db.rockDao().getAllForStyle(AscendStyle.ePROJECT.id)
-
-    fun getBotchedRocks() = _db.rockDao().getAllForStyle(AscendStyle.eBOTCHED.id)
 
     fun getRock(rockId: Int) =_db.rockDao().getRock(rockId)
 
     fun getRockComments(rockId: Int) = _db.rockCommentDao().getAll(rockId)
 
-    fun getProjectedRoutes(rockId: Int) = _db.routeDao().getAllForStyle(rockId, AscendStyle.ePROJECT.id)
+    fun getRoutesForRock(rockId: Int) = _db.routeDao().getAllAtRock(rockId)
 
-    fun getBotchedRoutes(rockId: Int) = _db.routeDao().getAllForStyle(rockId, AscendStyle.eBOTCHED.id)
+    fun getProjectedRoutesForRock(rockId: Int) = _db.routeDao().getAllAtRockForStyle(rockId, AscendStyle.ePROJECT.id)
 
-    fun getRoutes(rockId: Int) = _db.routeDao().getAll(rockId)
+    fun getBotchedRoutesForRock(rockId: Int) = _db.routeDao().getAllAtRockForStyle(rockId, AscendStyle.eBOTCHED.id)
+
+    fun getRoutesForSector(sectorId: Int) = _db.routeDao().getAllInSector(sectorId)
+
+    fun getProjectedRoutesForSector(sectorId: Int) = _db.routeDao().getAllInSectorForStyle(sectorId, AscendStyle.ePROJECT.id)
+
+    fun getBotchedRoutesForSector(sectorId: Int) = _db.routeDao().getAllInSectorForStyle(sectorId, AscendStyle.eBOTCHED.id)
+
+    fun getRoutesForRegion(regionId: Int) = _db.routeDao().getAllInRegion(regionId)
+
+    fun getProjectedRoutesForRegion(regionId: Int) = _db.routeDao().getAllInRegionForStyle(regionId, AscendStyle.ePROJECT.id)
+
+    fun getBotchedRoutesForRegion(regionId: Int) = _db.routeDao().getAllInRegionForStyle(regionId, AscendStyle.eBOTCHED.id)
+
+    fun getRoutesForCountry(countryName: String) = _db.routeDao().getAllInCountry(countryName)
+
+    fun getProjectedRoutesForCountry(countryName: String) = _db.routeDao().getAllInCountryForStyle(countryName, AscendStyle.ePROJECT.id)
+
+    fun getBotchedRoutesForCountry(countryName: String) = _db.routeDao().getAllInCountryForStyle(countryName, AscendStyle.eBOTCHED.id)
+
+    fun getRoutes() = _db.routeDao().all
+
+    fun getProjectedRoutes() = _db.routeDao().getAllForStyle(AscendStyle.ePROJECT.id)
+
+    fun getBotchedRoutes() = _db.routeDao().getAllForStyle(AscendStyle.eBOTCHED.id)
 
     fun getRoute(routeId: Int) = _db.routeDao().getRoute(routeId)
 

--- a/app/src/main/java/com/yacgroup/yacguide/database/RockDao.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/RockDao.kt
@@ -19,9 +19,7 @@ package com.yacgroup.yacguide.database
 
 import androidx.room.*
 import com.yacgroup.yacguide.database.SqlMacros.Companion.DELETE_ROCKS
-import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_REGION
 import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_ROCK
-import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_SECTOR
 import com.yacgroup.yacguide.database.SqlMacros.Companion.SELECT_ROCKS
 import com.yacgroup.yacguide.database.SqlMacros.Companion.VIA_ROCKS_ROUTES
 import com.yacgroup.yacguide.database.SqlMacros.Companion.VIA_ROCKS_SECTOR
@@ -33,26 +31,14 @@ interface RockDao {
     @get:Query(SELECT_ROCKS)
     val all: List<Rock>
 
-    @Query("$SELECT_ROCKS $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION $VIA_ROCKS_ROUTES $VIA_ROUTES_ASCENDS WHERE Ascend.styleId = :styleId $ORDERED_BY_REGION")
-    fun getAllForStyle(styleId: Int): List<Rock>
-
     @Query("$SELECT_ROCKS $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION WHERE Region.country = :countryName")
     fun getAllInCountry(countryName: String): List<Rock>
-
-    @Query("$SELECT_ROCKS $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION $VIA_ROCKS_ROUTES $VIA_ROUTES_ASCENDS WHERE Region.country = :countryName AND Ascend.styleId = :styleId $ORDERED_BY_REGION")
-    fun getAllInCountryForStyle(countryName: String, styleId: Int): List<Rock>
 
     @Query("$SELECT_ROCKS $VIA_ROCKS_SECTOR WHERE Sector.parentId = :regionId")
     fun getAllInRegion(regionId: Int): List<Rock>
 
-    @Query("$SELECT_ROCKS $VIA_ROCKS_SECTOR $VIA_ROCKS_ROUTES $VIA_ROUTES_ASCENDS WHERE Sector.parentId = :regionId AND Ascend.styleId = :styleId $ORDERED_BY_SECTOR")
-    fun getAllInRegionForStyle(regionId: Int, styleId: Int): List<Rock>
-
     @Query("$SELECT_ROCKS WHERE Rock.parentId = :sectorId $ORDERED_BY_ROCK")
     fun getAllInSector(sectorId: Int): List<Rock>
-
-    @Query("$SELECT_ROCKS $VIA_ROCKS_ROUTES $VIA_ROUTES_ASCENDS WHERE Rock.parentId = :sectorId AND Ascend.styleId = :styleId $ORDERED_BY_ROCK")
-    fun getAllInSectorForStyle(sectorId: Int, styleId: Int): List<Rock>
 
     @Query("$SELECT_ROCKS WHERE Rock.id = :id")
     fun getRock(id: Int): Rock?

--- a/app/src/main/java/com/yacgroup/yacguide/database/RouteDao.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/RouteDao.kt
@@ -19,7 +19,10 @@ package com.yacgroup.yacguide.database
 
 import androidx.room.*
 import com.yacgroup.yacguide.database.SqlMacros.Companion.DELETE_ROUTES
+import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_REGION
+import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_ROCK
 import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_ROUTE
+import com.yacgroup.yacguide.database.SqlMacros.Companion.ORDERED_BY_SECTOR
 import com.yacgroup.yacguide.database.SqlMacros.Companion.SELECT_ROUTES
 import com.yacgroup.yacguide.database.SqlMacros.Companion.VIA_ROCKS_SECTOR
 import com.yacgroup.yacguide.database.SqlMacros.Companion.VIA_ROUTES_ASCENDS
@@ -31,17 +34,32 @@ interface RouteDao {
     @get:Query(SELECT_ROUTES)
     val all: List<Route>
 
-    @Query("$SELECT_ROUTES WHERE Route.parentId = :parentId $ORDERED_BY_ROUTE")
-    fun getAll(parentId: Int): List<Route>
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ASCENDS WHERE Ascend.styleId = :styleId $ORDERED_BY_ROUTE")
+    fun getAllForStyle(styleId: Int): List<Route>
 
-    @Query("$SELECT_ROUTES $VIA_ROUTES_ASCENDS WHERE Route.parentId = :parentId AND Ascend.styleId = :styleId $ORDERED_BY_ROUTE")
-    fun getAllForStyle(parentId: Int, styleId: Int): List<Route>
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION WHERE Region.country = :countryName $ORDERED_BY_REGION")
+    fun getAllInCountry(countryName: String): List<Route>
 
-    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR WHERE Sector.parentId = :regionId")
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION $VIA_ROUTES_ASCENDS WHERE Region.country = :countryName AND Ascend.styleId = :styleId $ORDERED_BY_REGION")
+    fun getAllInCountryForStyle(countryName: String, styleId: Int): List<Route>
+
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR WHERE Sector.parentId = :regionId $ORDERED_BY_SECTOR")
     fun getAllInRegion(regionId: Int): List<Route>
 
-    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR $VIA_SECTORS_REGION WHERE Region.country = :countryName")
-    fun getAllInCountry(countryName: String): List<Route>
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROCKS_SECTOR $VIA_ROUTES_ASCENDS WHERE Sector.parentId = :regionId AND Ascend.styleId = :styleId $ORDERED_BY_SECTOR")
+    fun getAllInRegionForStyle(regionId: Int, styleId: Int): List<Route>
+
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK WHERE Rock.parentId = :sectorId $ORDERED_BY_ROCK")
+    fun getAllInSector(sectorId: Int): List<Route>
+
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ROCK $VIA_ROUTES_ASCENDS WHERE Rock.parentId = :sectorId AND Ascend.styleId = :styleId $ORDERED_BY_ROCK")
+    fun getAllInSectorForStyle(sectorId: Int, styleId: Int): List<Route>
+
+    @Query("$SELECT_ROUTES WHERE Route.parentId = :rockId $ORDERED_BY_ROUTE")
+    fun getAllAtRock(rockId: Int): List<Route>
+
+    @Query("$SELECT_ROUTES $VIA_ROUTES_ASCENDS WHERE Route.parentId = :rockId AND Ascend.styleId = :styleId $ORDERED_BY_ROUTE")
+    fun getAllAtRockForStyle(rockId: Int, styleId: Int): List<Route>
 
     @Query("$SELECT_ROUTES WHERE Route.id = :id")
     fun getRoute(id: Int): Route?

--- a/app/src/main/res/layout/appbar_info_and_map.xml
+++ b/app/src/main/res/layout/appbar_info_and_map.xml
@@ -42,6 +42,7 @@
                 android:onClick="showComments"/>
 
             <ImageButton
+                android:id="@+id/mapButton"
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 app:srcCompat="@drawable/ic_baseline_map_24"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="search">Suchen</string>
     <string name="comments">Kommentare</string>
     <string name="name">Name</string>
-    <string name="arrow">\u2794</string>
+    <string name="right_arrow">\u2794</string>
 
     <!-- Menu -->
     <string name="menu_database">Datenbank</string>
@@ -85,7 +85,8 @@
     <string name="ascend_deleted">Begehung gelöscht</string>
     <string name="hint_no_name">Kein Name eingegeben</string>
     <string name="hint_name_already_used">Name bereits vergeben</string>
-    <string name="hint_rock_not_found">Keine Felsen gefunden</string>
+    <string name="no_rocks_available">Keine Felsen vorhanden</string>
+    <string name="no_routes_available">Keine Wege vorhanden</string>
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="no_map_app_available">Keine Karten-App verfügbar</string>
     <string name="no_webbrowser_available">Kein Webbrowser verfügbar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,8 +85,6 @@
     <string name="ascend_deleted">Begehung gelöscht</string>
     <string name="hint_no_name">Kein Name eingegeben</string>
     <string name="hint_name_already_used">Name bereits vergeben</string>
-    <string name="no_rocks_available">Keine Felsen vorhanden</string>
-    <string name="no_routes_available">Keine Wege vorhanden</string>
     <string name="no_internet_connection">Keine Internetverbindung</string>
     <string name="no_map_app_available">Keine Karten-App verfügbar</string>
     <string name="no_webbrowser_available">Kein Webbrowser verfügbar</string>


### PR DESCRIPTION
Resolves #255 

-> project and botch filters now point to `RouteActivity` to show real projects/botches instead of the according rocks