### PR TITLE
Add database reset

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/PreferencesActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/PreferencesActivity.kt
@@ -31,8 +31,8 @@ import com.yacgroup.yacguide.utils.DialogWidgetBuilder
 
 class PreferencesActivity : BaseNavigationActivity() {
 
-    private lateinit var _customSettings: SharedPreferences
     private lateinit var _db: DatabaseWrapper
+    private lateinit var _customSettings: SharedPreferences
 
     private val _settingKeysMap = mapOf(R.id.tourbookOrderingCheckbox to Pair(R.string.order_tourbook_chronologically,
                                                                               R.bool.order_tourbook_chronologically),

--- a/app/src/main/res/layout/content_preferences.xml
+++ b/app/src/main/res/layout/content_preferences.xml
@@ -162,6 +162,16 @@
 
         <View style="@style/FatDivider"/>
 
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="10dp"
+            android:layout_margin="10dp"
+            android:id="@+id/resetDatabaseButton"
+            android:text="@string/reset_database"
+            android:textSize="16sp"
+            android:onClick="resetDatabase"/>
+
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,7 +152,8 @@
     <string name="colorize_tourbook_entries">Tourenbucheinträge färben</string>
 
     <string name="reset_database">Auf Werkseinstellungen zurücksetzen</string>
-    <string name="reset_database_confirm">Datenbank (inkl. Tourenbuch) löschen. Fortfahren?</string>
+    <string name="reset_database_confirm">Dies löscht die gesamte Datenbank, inkl. Tourenbuch.
+                                          Fortfahren?</string>
     <string name="reset_database_done">Auf Werkseinstellungen zurückgesetzt</string>
 
     <string name="only_official_summits">Nur offizielle Gipfel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,6 +151,10 @@
     <string name="follow">Nachstieg</string>
     <string name="colorize_tourbook_entries">Tourenbucheinträge färben</string>
 
+    <string name="reset_database">Auf Werkseinstellungen zurücksetzen</string>
+    <string name="reset_database_confirm">Datenbank (inkl. Tourenbuch) löschen. Fortfahren?</string>
+    <string name="reset_database_done">Auf Werkseinstellungen zurückgesetzt</string>
+
     <string name="only_official_summits">Nur offizielle Gipfel</string>
     <string name="only_official_routes">Nur offizielle Wege</string>
 


### PR DESCRIPTION
Add a reset database button ("Auf Werkseinstellungen zurücksetzen") to the preferences view. After a confirmation dialog it clears the database and tour book and also resets the custom settings to the default values. After deleting a success toast is shown.

For future bugs it might be helpful to give the user the opportunity to reset all databases in the app.

Resolves #242