### PR TITLE
Updating country list on updating all via region manager

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
@@ -27,7 +27,7 @@ import com.yacgroup.yacguide.utils.DialogWidgetBuilder
 import com.yacgroup.yacguide.utils.NetworkUtils
 
 class UpdateHandler(private val _activity: AppCompatActivity,
-                    private val _jsonParser: JSONWebParser): UpdateListener {
+                    private var _jsonParser: JSONWebParser): UpdateListener {
 
     private var _updateDialog: Dialog
     private var _isRecurringUpdate: Boolean = false
@@ -58,6 +58,11 @@ class UpdateHandler(private val _activity: AppCompatActivity,
         }
     }
 
+    fun setJsonParser(parser: JSONWebParser) {
+        _jsonParser = parser
+        _jsonParser.listener = this
+    }
+
     fun update(onUpdateFinished: () -> Unit = {}, isRecurring: Boolean = false) {
         _onUpdateFinished = onUpdateFinished
         _isRecurringUpdate = isRecurring
@@ -66,7 +71,6 @@ class UpdateHandler(private val _activity: AppCompatActivity,
             return
         }
         _jsonParser.fetchData()
-        _updateDialog.setContentView(R.layout.info_dialog)
         _updateDialog.show()
     }
 
@@ -93,6 +97,9 @@ class UpdateHandler(private val _activity: AppCompatActivity,
         } else {
             Toast.makeText(_activity, R.string.error_on_refresh, Toast.LENGTH_SHORT).show()
         }
+
+        _updateDialog.findViewById<TextView>(R.id.dialogText).setText(R.string.dialog_loading)
+        _success = true
     }
 
     fun getDownloadButton(onUpdateFinished: () -> Unit): ImageButton {

--- a/app/src/main/java/com/yacgroup/yacguide/database/CountryDao.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/CountryDao.kt
@@ -20,12 +20,16 @@ package com.yacgroup.yacguide.database
 import androidx.room.*
 import com.yacgroup.yacguide.database.SqlMacros.Companion.DELETE_COUNTRIES
 import com.yacgroup.yacguide.database.SqlMacros.Companion.SELECT_COUNTRIES
+import com.yacgroup.yacguide.database.SqlMacros.Companion.VIA_COUNTRIES_REGIONS
 
 @Dao
 interface CountryDao {
 
     @get:Query(SELECT_COUNTRIES)
     val all: List<Country>
+
+    @Query("$SELECT_COUNTRIES $VIA_COUNTRIES_REGIONS")
+    fun getAllNonEmpty(): List<Country>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(countries: List<Country>)

--- a/app/src/main/java/com/yacgroup/yacguide/database/DatabaseWrapper.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/DatabaseWrapper.kt
@@ -44,6 +44,8 @@ class DatabaseWrapper(context: Context) {
 
     fun getCountries() = _db.countryDao().all
 
+    fun getNonEmptyCountries() = _db.countryDao().getAllNonEmpty()
+
     fun getRegions(countryName: String) = _db.regionDao().getAll(countryName)
 
     fun getNonEmptyRegions() = _db.regionDao().getAllNonEmpty()

--- a/app/src/main/java/com/yacgroup/yacguide/database/SqlMacros.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/SqlMacros.kt
@@ -67,5 +67,6 @@ class SqlMacros {
         const val VIA_SECTORS_REGION = "JOIN Region ON Region.id = Sector.parentId"
         const val VIA_COMMENTS_REGION = "JOIN Region ON Region.id = RegionComment.regionId"
         const val VIA_REGIONS_SECTORS = "JOIN Sector ON Sector.parentId = Region.id"
+        const val VIA_COUNTRIES_REGIONS = "JOIN Region ON Region.country = Country.name"
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/network/CountryParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/CountryParser.kt
@@ -17,7 +17,6 @@
 
 package com.yacgroup.yacguide.network
 
-import com.yacgroup.yacguide.UpdateListener
 import com.yacgroup.yacguide.database.Country
 import com.yacgroup.yacguide.database.DatabaseWrapper
 

--- a/app/src/main/java/com/yacgroup/yacguide/network/RegionParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/RegionParser.kt
@@ -17,7 +17,6 @@
 
 package com.yacgroup.yacguide.network
 
-import com.yacgroup.yacguide.UpdateListener
 import com.yacgroup.yacguide.database.DatabaseWrapper
 import com.yacgroup.yacguide.database.Region
 import com.yacgroup.yacguide.utils.NetworkUtils
@@ -28,10 +27,8 @@ import org.json.JSONException
 import java.util.*
 import kotlin.jvm.Throws
 
-class RegionParser(
-        private val _db: DatabaseWrapper,
-        private val _countryName: String)
-    : JSONWebParser() {
+class RegionParser(private val _db: DatabaseWrapper,
+                   private var _countryName: String) : JSONWebParser() {
 
     private val _regions = mutableListOf<Region>()
 
@@ -60,5 +57,9 @@ class RegionParser(
         _db.deleteRegions(_countryName)
         _db.addRegions(_regions)
         super.onFinalTaskResolved()
+    }
+
+    fun setCountryName(name: String) {
+        _countryName = name
     }
 }


### PR DESCRIPTION
Resolves #285 

This PR adds update of country list to the update-all functionality in the region manager.

Note: The fact that updating is asynchronous leads to the (in my eyes) ugly callback implementation where we pass the next element's processing as a callback to the current one's update to be executed after that is finished.

In the future, we might think of refactoring this to Promise pattern.