### PR TITLE
Do not re-display rock and route lists on instantiating search bar

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
@@ -50,8 +50,9 @@ class RockActivity : TableActivityWithOptionsMenu() {
             R.string.rock_search,
             getString(R.string.only_official_summits),
             resources.getBoolean(R.bool.only_official_summits),
-            customSettings
-        ) { rockNamePart, onlyOfficialSummits -> _onSearchBarUpdate(rockNamePart, onlyOfficialSummits) }
+            customSettings,
+            { onlyOfficialSummits -> _onlyOfficialSummits = onlyOfficialSummits },
+            { rockNamePart, onlyOfficialSummits -> _onSearchBarUpdate(rockNamePart, onlyOfficialSummits) })
     }
 
     override fun getLayoutId() = R.layout.activity_rock

--- a/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
@@ -56,8 +56,9 @@ class RouteActivity : TableActivityWithOptionsMenu() {
             R.string.route_search,
             getString(R.string.only_official_routes),
             resources.getBoolean(R.bool.only_official_routes),
-            customSettings
-        ) { routeNamePart, onlyOfficialRoutes -> _onSearchBarUpdate(routeNamePart, onlyOfficialRoutes) }
+            customSettings,
+            { onlyOfficialRoutes -> _onlyOfficialRoutes = onlyOfficialRoutes },
+            { routeNamePart, onlyOfficialRoutes -> _onSearchBarUpdate(routeNamePart, onlyOfficialRoutes) })
 
         if (activityLevel.level == ClimbingObjectLevel.eRoute) {
             _rock = db.getRock(activityLevel.parentId)

--- a/app/src/main/java/com/yacgroup/yacguide/utils/SearchBarHandler.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/utils/SearchBarHandler.kt
@@ -33,6 +33,7 @@ class SearchBarHandler(searchBarLayout: ConstraintLayout,
                        checkBoxTitle: String,
                        checkBoxDefaultValue: Boolean,
                        private val _settings: SharedPreferences,
+                       private val _initCallback: (Boolean) -> Unit,
                        private val _updateCallback: (String, Boolean) -> Unit) {
 
     private var _namePart: String = ""
@@ -67,7 +68,7 @@ class SearchBarHandler(searchBarLayout: ConstraintLayout,
             })
         }
 
-        _updateCallback(_namePart, _onlyOfficialObjects)
+        _initCallback(_onlyOfficialObjects)
     }
 
     fun storeCustomSettings(key: String) {


### PR DESCRIPTION
Rock and route lists were displayed twice on creating the corresponding activity which doubles the time for time-consuming widgets creation.