### PR TITLE
Unified ascend-ascent naming clash

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/AscendActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/AscendActivity.kt
@@ -58,10 +58,10 @@ class AscendActivity : AppCompatActivity() {
         _db = DatabaseWrapper(this)
 
         // The database query is different from null,
-        // if this activity is called from the TourbookAscendActivity (on editing an ascent).
+        // if this activity is called from the TourbookAscendActivity (on editing an ascend).
         _outdatedAscend = _db.getAscend(intent.getIntExtra(IntentConstants.ASCEND_ID, DatabaseWrapper.INVALID_ID))
         // The intent constant CLIMBING_OBJECT_PARENT_ID is only available, if this activity is called from
-        // the route DescriptionActivity (on entering a new ascent).
+        // the route DescriptionActivity (on entering a new ascend).
         _route = _db.getRoute(_outdatedAscend?.routeId
                     ?: intent.getIntExtra(IntentConstants.CLIMBING_OBJECT_PARENT_ID, DatabaseWrapper.INVALID_ID))
         // Beware: _route may still be null (if the route of this ascend has been deleted meanwhile)

--- a/app/src/main/java/com/yacgroup/yacguide/CountryActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/CountryActivity.kt
@@ -37,7 +37,7 @@ class CountryActivity : TableActivityWithOptionsMenu() {
         properties = arrayListOf(
             RouteSearchable(this),
             RockSearchable(this),
-            AscentFilterable(this)
+            AscendFilterable(this)
         )
 
         _viewAdapter = CountryViewAdapter { countryName -> _onCountrySelected(countryName) }

--- a/app/src/main/java/com/yacgroup/yacguide/DescriptionActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/DescriptionActivity.kt
@@ -24,12 +24,12 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.yacgroup.yacguide.database.Route
-import com.yacgroup.yacguide.list_adapters.AscentViewAdapter
+import com.yacgroup.yacguide.list_adapters.AscendViewAdapter
 import com.yacgroup.yacguide.utils.*
 
 class DescriptionActivity : TableActivity() {
 
-    private lateinit var _viewAdapter: AscentViewAdapter
+    private lateinit var _viewAdapter: AscendViewAdapter
     private lateinit var _route: Route
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -41,8 +41,8 @@ class DescriptionActivity : TableActivity() {
                 "${getString(R.string.route_restricted)} ${Route.STATUS[_route.statusId]}"
         }
 
-        _viewAdapter = AscentViewAdapter(this, customSettings) {
-            ascentId -> _onAscentSelected(ascentId)
+        _viewAdapter = AscendViewAdapter(this, customSettings) {
+            ascendId -> _onAscendSelected(ascendId)
         }
         findViewById<RecyclerView>(R.id.tableRecyclerView).adapter = _viewAdapter
     }
@@ -69,20 +69,20 @@ class DescriptionActivity : TableActivity() {
         val routeName = ParserUtils.decodeObjectNames(_route.name)
         this.title = "${if (routeName.first.isNotEmpty()) routeName.first else routeName.second}   ${_route.grade.orEmpty()}"
 
-        var firstAscentClimbers = _route.firstAscendLeader
+        var firstAscendClimbers = _route.firstAscendLeader
                 ?.takeUnless { it.isEmpty() }
                 ?: getString(R.string.first_ascend_unknown)
-        firstAscentClimbers += _route.firstAscendFollower
+        firstAscendClimbers += _route.firstAscendFollower
                 ?.takeUnless { it.isEmpty() }
                 ?.let { ", $it" }
                 ?: ""
-        val firstAscentDate = _route.firstAscendDate
+        val firstAscendDate = _route.firstAscendDate
                 ?.takeUnless { it == DateUtils.UNKNOWN_DATE }
                 ?.let { DateUtils.formatDate(it) }
                 ?: getString(R.string.date_unknown)
 
-        findViewById<TextView>(R.id.firstAscentClimbersTextView).text = firstAscentClimbers
-        findViewById<TextView>(R.id.firstAscentDateTextView).text = firstAscentDate
+        findViewById<TextView>(R.id.firstAscendClimbersTextView).text = firstAscendClimbers
+        findViewById<TextView>(R.id.firstAscendDateTextView).text = firstAscendDate
 
         _route.typeOfClimbing?.takeIf { it.isNotEmpty() }?.let {
             findViewById<ConstraintLayout>(R.id.typeOfClimbingLayout).visibility = View.VISIBLE
@@ -91,16 +91,16 @@ class DescriptionActivity : TableActivity() {
 
         findViewById<TextView>(R.id.routeDescriptionTextView).text = _route.description
 
-        val ascents = db.getRouteAscends(_route.id)
-        findViewById<TextView>(R.id.myAscentsTextView).visibility =
-            if (ascents.isEmpty()) View.GONE
+        val ascends = db.getRouteAscends(_route.id)
+        findViewById<TextView>(R.id.myAscendsTextView).visibility =
+            if (ascends.isEmpty()) View.GONE
             else View.VISIBLE
-        _viewAdapter.submitList(ascents)
+        _viewAdapter.submitList(ascends)
     }
 
-    private fun _onAscentSelected(ascentId: Int) {
+    private fun _onAscendSelected(ascendId: Int) {
         startActivity(Intent(this@DescriptionActivity, TourbookAscendActivity::class.java).apply {
-            putExtra(IntentConstants.ASCEND_ID, ascentId)
+            putExtra(IntentConstants.ASCEND_ID, ascendId)
         })
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/RegionActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RegionActivity.kt
@@ -37,7 +37,7 @@ class RegionActivity : TableActivityWithOptionsMenu() {
         properties = arrayListOf(
             RouteSearchable(this),
             RockSearchable(this),
-            AscentFilterable(this)
+            AscendFilterable(this)
         )
 
         _viewAdapter = RegionViewAdapter(this, db) { regionId, regionName -> _onRegionSelected(regionId, regionName) }

--- a/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RockActivity.kt
@@ -20,9 +20,8 @@ package com.yacgroup.yacguide
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.*
 import androidx.recyclerview.widget.RecyclerView
-import com.yacgroup.yacguide.activity_properties.AscentFilterable
+import com.yacgroup.yacguide.activity_properties.AscendFilterable
 import com.yacgroup.yacguide.activity_properties.RockSearchable
 import com.yacgroup.yacguide.activity_properties.RouteSearchable
 import com.yacgroup.yacguide.database.Rock
@@ -51,7 +50,7 @@ class RockActivity : TableActivityWithOptionsMenu() {
         properties = arrayListOf(
             RouteSearchable(this),
             RockSearchable(this),
-            AscentFilterable(this)
+            AscendFilterable(this)
         )
 
         _rockGettersMap = mapOf(

--- a/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RouteActivity.kt
@@ -25,7 +25,7 @@ import android.view.View
 import android.widget.*
 import androidx.recyclerview.widget.RecyclerView
 
-import com.yacgroup.yacguide.activity_properties.AscentFilterable
+import com.yacgroup.yacguide.activity_properties.AscendFilterable
 import com.yacgroup.yacguide.activity_properties.RouteSearchable
 import com.yacgroup.yacguide.database.Rock
 import com.yacgroup.yacguide.database.Route
@@ -66,7 +66,7 @@ class RouteActivity : TableActivityWithOptionsMenu() {
 
         properties = arrayListOf(
             RouteSearchable(this),
-            AscentFilterable(this)
+            AscendFilterable(this)
         )
 
         _routeGettersMap = mapOf(

--- a/app/src/main/java/com/yacgroup/yacguide/SectorActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/SectorActivity.kt
@@ -20,7 +20,6 @@ package com.yacgroup.yacguide
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.*
 import androidx.recyclerview.widget.RecyclerView
 import com.yacgroup.yacguide.activity_properties.*
 import com.yacgroup.yacguide.list_adapters.SectorViewAdapter
@@ -39,7 +38,7 @@ class SectorActivity : TableActivityWithOptionsMenu() {
         properties = arrayListOf(
             RouteSearchable(this),
             RockSearchable(this),
-            AscentFilterable(this)
+            AscendFilterable(this)
         )
 
         _viewAdapter = SectorViewAdapter(this, customSettings, db) { sectorId, sectorName -> _onSectorSelected(sectorId, sectorName) }

--- a/app/src/main/java/com/yacgroup/yacguide/TourbookAscendActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/TourbookAscendActivity.kt
@@ -32,7 +32,7 @@ import com.yacgroup.yacguide.utils.*
 class TourbookAscendActivity : BaseNavigationActivity() {
 
     private lateinit var _db: DatabaseWrapper
-    private lateinit var _ascent: Ascend
+    private lateinit var _ascend: Ascend
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -40,8 +40,8 @@ class TourbookAscendActivity : BaseNavigationActivity() {
 
         _db = DatabaseWrapper(this)
 
-        val ascentId = intent.getIntExtra(IntentConstants.ASCEND_ID, DatabaseWrapper.INVALID_ID)
-        _ascent = _db.getAscend(ascentId)!!
+        val ascendId = intent.getIntExtra(IntentConstants.ASCEND_ID, DatabaseWrapper.INVALID_ID)
+        _ascend = _db.getAscend(ascendId)!!
     }
 
     override fun getLayoutId() = R.layout.activity_tourbook_ascend
@@ -53,7 +53,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
 
     override fun onResume() {
         super.onResume()
-        _ascent = _db.getAscend(_ascent.id)!!
+        _ascend = _db.getAscend(_ascend.id)!!
         _displayContent()
     }
 
@@ -68,7 +68,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
 
     private fun edit() {
         startActivity(Intent(this@TourbookAscendActivity, AscendActivity::class.java).apply {
-            putExtra(IntentConstants.ASCEND_ID, _ascent.id)
+            putExtra(IntentConstants.ASCEND_ID, _ascend.id)
         })
     }
 
@@ -77,7 +77,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
             setIcon(android.R.drawable.ic_dialog_alert)
             setNegativeButton()
             setPositiveButton { _, _ ->
-                _db.deleteAscend(_ascent)
+                _db.deleteAscend(_ascend)
                 Toast.makeText(this@TourbookAscendActivity, R.string.ascend_deleted, Toast.LENGTH_SHORT).show()
                 finish()
             }
@@ -88,7 +88,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
         val layout = findViewById<LinearLayout>(R.id.tableLayout)
         layout.removeAllViews()
 
-        var route = _db.getRoute(_ascent.routeId)
+        var route = _db.getRoute(_ascend.routeId)
         val rock: Rock
         val sector: Sector
         val region: Region
@@ -104,11 +104,11 @@ class TourbookAscendActivity : BaseNavigationActivity() {
             Toast.makeText(this, R.string.corresponding_route_not_found, Toast.LENGTH_LONG).show()
         }
 
-        val partnerNames = _db.getPartnerNames(_ascent.partnerIds?.toList().orEmpty())
+        val partnerNames = _db.getPartnerNames(_ascend.partnerIds?.toList().orEmpty())
         val partnersString = TextUtils.join(", ", partnerNames)
 
         layout.addView(WidgetUtils.createCommonRowLayout(this,
-                textLeft = "${_ascent.day}.${_ascent.month}.${_ascent.year}",
+                textLeft = "${_ascend.day}.${_ascend.month}.${_ascend.year}",
                 textRight = region.name.orEmpty(),
                 textSizeDp = WidgetUtils.infoFontSizeDp,
                 bgColor = WidgetUtils.tourHeaderColor))
@@ -147,7 +147,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
                 typeface = Typeface.NORMAL))
         layout.addView(WidgetUtils.createCommonRowLayout(this,
                 textLeft = route.grade.orEmpty(),
-                textRight = AscendStyle.fromId(_ascent.styleId)?.styleName.orEmpty()))
+                textRight = AscendStyle.fromId(_ascend.styleId)?.styleName.orEmpty()))
         layout.addView(WidgetUtils.createHorizontalLine(this, 1))
         layout.addView(WidgetUtils.createCommonRowLayout(this,
                 textLeft = getString(R.string.partner),
@@ -161,7 +161,7 @@ class TourbookAscendActivity : BaseNavigationActivity() {
                 textSizeDp = WidgetUtils.textFontSizeDp,
                 typeface = Typeface.NORMAL))
         layout.addView(WidgetUtils.createCommonRowLayout(this,
-                textLeft = _ascent.notes?.takeUnless { it.isBlank() } ?: " - "))
+                textLeft = _ascend.notes?.takeUnless { it.isBlank() } ?: " - "))
         layout.addView(WidgetUtils.createHorizontalLine(this, 1))
     }
 

--- a/app/src/main/java/com/yacgroup/yacguide/activity_properties/AscendFilterable.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/activity_properties/AscendFilterable.kt
@@ -23,7 +23,7 @@ import com.yacgroup.yacguide.RouteActivity
 import com.yacgroup.yacguide.TableActivityWithOptionsMenu
 import com.yacgroup.yacguide.utils.IntentConstants
 
-class AscentFilterable(private val _activity: TableActivityWithOptionsMenu) : ActivityProperty {
+class AscendFilterable(private val _activity: TableActivityWithOptionsMenu) : ActivityProperty {
 
     override fun getMenuGroupId() = R.id.group_filter
 

--- a/app/src/main/java/com/yacgroup/yacguide/database/tourbook/TourbookExporter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/database/tourbook/TourbookExporter.kt
@@ -146,9 +146,9 @@ class TourbookExporter(
         val jsonAscends = JSONArray(jsonString)
         _db.deleteAscends()
         _db.deletePartners()
-        val ascents = mutableListOf<Ascend>()
+        val ascends = mutableListOf<Ascend>()
         val partners = mutableListOf<Partner>()
-        var ascentId = 1
+        var ascendId = 1
         var partnerId = 1
         for (i in 0 until jsonAscends.length()) {
             val jsonAscend = jsonAscends.getJSONObject(i)
@@ -165,8 +165,8 @@ class TourbookExporter(
                 }
                 partnerIds.add(partner.id)
             }
-            val ascent = Ascend(
-                id = ascentId++,
+            val ascend = Ascend(
+                id = ascendId++,
                 routeId = ParserUtils.jsonField2Int(jsonAscend, _routeIdKey),
                 styleId = ParserUtils.jsonField2Int(jsonAscend, _styleIdKey),
                 year = ParserUtils.jsonField2Int(jsonAscend, _yearKey),
@@ -175,9 +175,9 @@ class TourbookExporter(
                 partnerIds = partnerIds,
                 notes = jsonAscend.getString(_notesKey)
             )
-            ascents.add(ascent)
+            ascends.add(ascend)
         }
         _db.addPartners(partners)
-        _db.addAscends(ascents)
+        _db.addAscends(ascends)
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/list_adapters/AscendViewAdapter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/list_adapters/AscendViewAdapter.kt
@@ -32,11 +32,11 @@ import com.yacgroup.yacguide.R
 import com.yacgroup.yacguide.database.Ascend
 import com.yacgroup.yacguide.utils.AscendStyle
 
-class AscentViewAdapter(
+class AscendViewAdapter(
     context: Context,
     customSettings: SharedPreferences,
     private val _onClick: (Int) -> Unit)
-    : ListAdapter<Ascend, RecyclerView.ViewHolder>(AscentDiffCallback) {
+    : ListAdapter<Ascend, RecyclerView.ViewHolder>(AscendDiffCallback) {
 
     private val _defaultBgColor = ContextCompat.getColor(context, R.color.colorSecondaryLight)
     private val _leadBgColor = customSettings.getInt(
@@ -46,25 +46,25 @@ class AscentViewAdapter(
         context.getString(R.string.follow),
         ContextCompat.getColor(context, R.color.color_follow))
 
-    inner class AscentViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    inner class AscendViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val _listItemLayout = view.findViewById<LinearLayout>(R.id.listItemLayout)
         private val _mainLeftTextView = view.findViewById<TextView>(R.id.mainLeftTextView)
         private val _subTextView = view.findViewById<TextView>(R.id.subTextView)
 
-        fun bind(ascent: Ascend) {
+        fun bind(ascend: Ascend) {
             val bgColor =
-                if (AscendStyle.isLead(AscendStyle.bitMask(ascent.styleId)))
+                if (AscendStyle.isLead(AscendStyle.bitMask(ascend.styleId)))
                     _leadBgColor
-                else if (AscendStyle.isFollow(AscendStyle.bitMask(ascent.styleId)))
+                else if (AscendStyle.isFollow(AscendStyle.bitMask(ascend.styleId)))
                     _followBgColor
                 else
                     _defaultBgColor
-            _mainLeftTextView.text = "${ascent.day}.${ascent.month}.${ascent.year}"
-            _subTextView.text = AscendStyle.fromId(ascent.styleId)?.styleName.orEmpty()
+            _mainLeftTextView.text = "${ascend.day}.${ascend.month}.${ascend.year}"
+            _subTextView.text = AscendStyle.fromId(ascend.styleId)?.styleName.orEmpty()
             _listItemLayout.apply {
                 setBackgroundColor(bgColor)
                 setOnClickListener {
-                    _onClick(ascent.id)
+                    _onClick(ascend.id)
                 }
             }
         }
@@ -73,20 +73,20 @@ class AscentViewAdapter(
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(viewGroup.context)
         val view = inflater.inflate(R.layout.list_data_item, viewGroup, false)
-        return AscentViewHolder(view)
+        return AscendViewHolder(view)
     }
 
     override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
-        (viewHolder as AscentViewHolder).bind(getItem(position) as Ascend)
+        (viewHolder as AscendViewHolder).bind(getItem(position) as Ascend)
     }
 }
 
-object AscentDiffCallback : DiffUtil.ItemCallback<Ascend>() {
-    override fun areItemsTheSame(oldAscent: Ascend, newAscent: Ascend): Boolean {
-        return oldAscent.id == newAscent.id
+object AscendDiffCallback : DiffUtil.ItemCallback<Ascend>() {
+    override fun areItemsTheSame(oldAscend: Ascend, newAscend: Ascend): Boolean {
+        return oldAscend.id == newAscend.id
     }
 
-    override fun areContentsTheSame(oldAscent: Ascend, newAscent: Ascend): Boolean {
-        return oldAscent == newAscent
+    override fun areContentsTheSame(oldAscend: Ascend, newAscend: Ascend): Boolean {
+        return oldAscend == newAscend
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/list_adapters/RockViewAdapter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/list_adapters/RockViewAdapter.kt
@@ -79,12 +79,12 @@ class RockViewAdapter(
                 typeface = Typeface.ITALIC
                 bgColor = _prohibitedBgColor
             }
-            bgColor = AscendStyle.deriveAscentColor(
+            bgColor = AscendStyle.deriveAscendColor(
                 rock.ascendsBitMask,
                 _leadBgColor,
                 _followBgColor,
                 defaultColor = bgColor)
-            val decorationAdd = AscendStyle.deriveAscentDecoration(
+            val decorationAdd = AscendStyle.deriveAscendDecoration(
                 rock.ascendsBitMask,
                 _botchIcon,
                 _projectIcon,

--- a/app/src/main/java/com/yacgroup/yacguide/list_adapters/RouteViewAdapter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/list_adapters/RouteViewAdapter.kt
@@ -76,12 +76,12 @@ class RouteViewAdapter(
                 typeface = Typeface.ITALIC
                 bgColor = _prohibitedBgColor
             }
-            bgColor = AscendStyle.deriveAscentColor(
+            bgColor = AscendStyle.deriveAscendColor(
                 route.ascendsBitMask,
                 _leadBgColor,
                 _followBgColor,
                 defaultColor = bgColor)
-            val decorationAdd = AscendStyle.deriveAscentDecoration(
+            val decorationAdd = AscendStyle.deriveAscendDecoration(
                 route.ascendsBitMask,
                 _botchIcon,
                 _projectIcon,

--- a/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
@@ -203,9 +203,9 @@ class SectorParser(private val _db: DatabaseWrapper,
             val routeId = ParserUtils.jsonField2Int(jsonRoute, "weg_ID")
             val firstName = jsonRoute.getString("wegname_d")
             val secondName = jsonRoute.getString("wegname_cz")
-            var ascentsBitMask = 0
+            var ascendsBitMask = 0
             // re-store route's bitmask if it is re-added after being marked as ascended in the past
-            _db.getRouteAscends(routeId).forEach { ascentsBitMask = (ascentsBitMask or AscendStyle.bitMask(it.styleId)) }
+            _db.getRouteAscends(routeId).forEach { ascendsBitMask = (ascendsBitMask or AscendStyle.bitMask(it.styleId)) }
             val route = Route(
                 id = routeId,
                 nr = ParserUtils.jsonField2Float(jsonRoute, "wegnr"),
@@ -217,7 +217,7 @@ class SectorParser(private val _db: DatabaseWrapper,
                 firstAscendDate = jsonRoute.getString("erstbegdatum"),
                 typeOfClimbing = jsonRoute.getString("kletterei"),
                 description = jsonRoute.getString("wegbeschr_d"),
-                ascendsBitMask = ascentsBitMask,
+                ascendsBitMask = ascendsBitMask,
                 parentId = ParserUtils.jsonField2Int(jsonRoute, "gipfelid")
             )
             _routes.add(route)

--- a/app/src/main/java/com/yacgroup/yacguide/utils/AscendStyle.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/utils/AscendStyle.kt
@@ -105,13 +105,13 @@ enum class AscendStyle (val id: Int, val styleName: String) {
             return hasAscendBit(mask and _PROJECT_BIT_MASK)
         }
 
-        fun deriveAscentColor(ascentBitMask: Int, leadColor: Int, followColor: Int, defaultColor: Int) = when {
-            isLead(ascentBitMask) -> leadColor
-            isFollow(ascentBitMask) -> followColor
+        fun deriveAscendColor(ascendsBitMask: Int, leadColor: Int, followColor: Int, defaultColor: Int) = when {
+            isLead(ascendsBitMask) -> leadColor
+            isFollow(ascendsBitMask) -> followColor
             else -> defaultColor
         }
 
-        fun deriveAscentDecoration(ascendsBitMask: Int, botchIcon: String, projectIcon: String, watchingIcon:String): String {
+        fun deriveAscendDecoration(ascendsBitMask: Int, botchIcon: String, projectIcon: String, watchingIcon:String): String {
             val botchAdd = if (isBotch(ascendsBitMask)) botchIcon else ""
             val projectAdd = if (isProject(ascendsBitMask)) projectIcon else ""
             val watchingAdd = if (isWatching(ascendsBitMask)) watchingIcon else ""

--- a/app/src/main/java/com/yacgroup/yacguide/utils/IntentConstants.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/utils/IntentConstants.kt
@@ -18,8 +18,8 @@
 package com.yacgroup.yacguide.utils
 
 object IntentConstants {
-    const val ASCEND_ID = "AscentId"
-    const val ASCEND_PARTNER_IDS = "AscentPartnerIds"
+    const val ASCEND_ID = "AscendId"
+    const val ASCEND_PARTNER_IDS = "AscendPartnerIds"
     const val CLIMBING_OBJECT_LEVEL = "ClimbingObjectLevel"
     const val CLIMBING_OBJECT_PARENT_ID = "ClimbingObjectParentId"
     const val CLIMBING_OBJECT_PARENT_NAME = "ClimbingObjectParentName"

--- a/app/src/main/res/layout/route_description.xml
+++ b/app/src/main/res/layout/route_description.xml
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content">
 
         <TextView
-            android:id="@+id/firstAscentClimbersTextView"
+            android:id="@+id/firstAscendClimbersTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="10dp"
@@ -39,10 +39,10 @@
             app:layout_constraintHorizontal_bias="0"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/firstAscentDateTextView"
+            app:layout_constraintEnd_toStartOf="@+id/firstAscendDateTextView"
             app:layout_constraintTop_toTopOf="parent"/>
         <TextView
-            android:id="@+id/firstAscentDateTextView"
+            android:id="@+id/firstAscendDateTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_margin="10dp"
@@ -92,7 +92,7 @@
         android:textStyle="bold"/>
 
     <TextView
-        android:id="@+id/myAscentsTextView"
+        android:id="@+id/myAscendsTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"


### PR DESCRIPTION
Changed all occurrences of `ascent` to `ascend`.

I know `ascend` is wrong and it should be `ascent`. But since we cannot change the db table names without migration logic, I changed all occurrences to `ascend`. It should be equal throughout the code base.

Once we need a db migration anyway someday, we may change everything to `ascent`. 