### PR TITLE
Made update progress info more accurate

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Fabian Kantereit
+ * Copyright (C) 2019, 2022 Axel Paetzold
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,8 +58,8 @@ abstract class JSONWebParser : NetworkListener {
     fun fetchData() {
         _processedRequestsCount = 0
         initNetworkRequests()
-        for (request in networkRequests) {
-            NetworkTask(request.requestId, this).execute(request.url)
+        networkRequests.forEach {
+            NetworkTask(it.requestId, this).execute(it.url)
         }
     }
 

--- a/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
@@ -163,9 +163,9 @@ class SectorParser(private val _db: DatabaseWrapper,
                     "${baseUrl}jsonkomment.php?app=yacguide&sektorid=$sectorId")
         )
         networkRequests.addAll(requests)
-        requests.map {
-            NetworkTask(it.requestId, this).execute(it.url) }
-
+        requests.forEach {
+            NetworkTask(it.requestId, this).execute(it.url)
+        }
     }
 
     @Throws(JSONException::class)
@@ -192,7 +192,6 @@ class SectorParser(private val _db: DatabaseWrapper,
             )
             _rocks.add(rock)
         }
-        listener?.onUpdateStatus("$_regionName ${ (100 * (++_parsedSectorCount)) / _sectorCount } %")
     }
 
     @Throws(JSONException::class)
@@ -205,7 +204,9 @@ class SectorParser(private val _db: DatabaseWrapper,
             val secondName = jsonRoute.getString("wegname_cz")
             var ascentsBitMask = 0
             // re-store route's bitmask if it is re-added after being marked as ascended in the past
-            _db.getRouteAscends(routeId).forEach { ascentsBitMask = (ascentsBitMask or AscendStyle.bitMask(it.styleId)) }
+            _db.getRouteAscends(routeId).forEach {
+                ascentsBitMask = ascentsBitMask or AscendStyle.bitMask(it.styleId)
+            }
             val route = Route(
                 id = routeId,
                 nr = ParserUtils.jsonField2Float(jsonRoute, "wegnr"),
@@ -222,6 +223,7 @@ class SectorParser(private val _db: DatabaseWrapper,
             )
             _routes.add(route)
         }
+        listener?.onUpdateStatus("$_regionName ${ (100 * (++_parsedSectorCount)) / _sectorCount } %")
     }
 
     @Throws(JSONException::class)
@@ -269,11 +271,11 @@ class SectorParser(private val _db: DatabaseWrapper,
 
     private fun _updateAscendedRocks() {
         // update already ascended rocks
-        val updatedRocks = _rocks.map {
-            for (ascend in _db.getRockAscends(it.id)) {
-                it.ascendsBitMask = it.ascendsBitMask or AscendStyle.bitMask(ascend.styleId)
+        val updatedRocks = _rocks.map { rock ->
+            _db.getRockAscends(rock.id).forEach { ascent ->
+                rock.ascendsBitMask = rock.ascendsBitMask or AscendStyle.bitMask(ascent.styleId)
             }
-            it
+            rock
         }
         _db.updateRocks(updatedRocks)
     }


### PR DESCRIPTION
Background:
- When updating a region, the progress info stays at 100% percent for a long time. 
- Reason being, that the SectorParser requests all rocks & routes for a sector at once. Since parsing routes takes much longer than parsing rocks (since there are more), it makes more sense to update the progress info not after parsing rocks but rather after parsing routes.