### PR TITLE
Make sector updates cancelable

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/RegionManagerActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RegionManagerActivity.kt
@@ -39,6 +39,7 @@ class RegionManagerActivity : BaseNavigationActivity() {
 
     private lateinit var _viewAdapter: BaseViewAdapter
     private lateinit var _db: DatabaseWrapper
+    private lateinit var _countryAndRegionParser: CountryAndRegionParser
     private lateinit var _sectorParser: SectorParser
     private lateinit var _updateHandler: UpdateHandler
     private lateinit var _customSettings: SharedPreferences
@@ -47,6 +48,7 @@ class RegionManagerActivity : BaseNavigationActivity() {
         super.onCreate(savedInstanceState)
 
         _db = DatabaseWrapper(this)
+        _countryAndRegionParser = CountryAndRegionParser(_db)
         _sectorParser = SectorParser(_db, 0)
         _updateHandler = UpdateHandler(this, _sectorParser)
         _customSettings = getSharedPreferences(getString(R.string.preferences_filename), Context.MODE_PRIVATE)
@@ -128,11 +130,10 @@ class RegionManagerActivity : BaseNavigationActivity() {
 
     private fun _updateAll() {
         // We need to update regions recursively since update() is asynchronous.
-        _updateHandler.setJsonParser(CountryAndRegionParser(_db))
+        _updateHandler.setJsonParser(_countryAndRegionParser)
         _updateHandler.update({
             _updateHandler.setJsonParser(_sectorParser)
-            _updateNextRegion(_db.getNonEmptyRegions().toMutableSet())
-                              }, isRecurring = true)
+            _updateNextRegion(_db.getNonEmptyRegions().toMutableSet()) }, isRecurring = true)
     }
 
     private fun _updateNextRegion(regions: MutableSet<Region>) {
@@ -141,7 +142,7 @@ class RegionManagerActivity : BaseNavigationActivity() {
             regions.remove(nextRegion)
             _sectorParser.setRegionId(nextRegion.id)
             _sectorParser.setRegionName(nextRegion.name.orEmpty())
-            _updateHandler.update({ _updateNextRegion(regions) }, true)
+            _updateHandler.update({ _updateNextRegion(regions) }, isRecurring = true)
         } catch (e: NoSuchElementException) {
             _updateHandler.finish()
         }

--- a/app/src/main/java/com/yacgroup/yacguide/RegionManagerActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/RegionManagerActivity.kt
@@ -131,9 +131,11 @@ class RegionManagerActivity : BaseNavigationActivity() {
     private fun _updateAll() {
         // We need to update regions recursively since update() is asynchronous.
         _updateHandler.setJsonParser(_countryAndRegionParser)
-        _updateHandler.update({
-            _updateHandler.setJsonParser(_sectorParser)
-            _updateNextRegion(_db.getNonEmptyRegions().toMutableSet()) }, isRecurring = true)
+        _updateHandler.update(
+            onUpdateFinished = {
+                _updateHandler.setJsonParser(_sectorParser)
+                _updateNextRegion(_db.getNonEmptyRegions().toMutableSet()) },
+            isRecurring = true)
     }
 
     private fun _updateNextRegion(regions: MutableSet<Region>) {
@@ -142,7 +144,9 @@ class RegionManagerActivity : BaseNavigationActivity() {
             regions.remove(nextRegion)
             _sectorParser.setRegionId(nextRegion.id)
             _sectorParser.setRegionName(nextRegion.name.orEmpty())
-            _updateHandler.update({ _updateNextRegion(regions) }, isRecurring = true)
+            _updateHandler.update(
+                onUpdateFinished = { _updateNextRegion(regions) },
+                isRecurring = true)
         } catch (e: NoSuchElementException) {
             _updateHandler.finish()
         }

--- a/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/JSONWebParser.kt
@@ -52,16 +52,18 @@ abstract class JSONWebParser : NetworkListener {
                 )
             } catch (e: JSONException) {
                 _exitCode = ExitCode.ERROR
+                onFinalTaskResolved(_exitCode)
+                return
             } catch (e: IllegalArgumentException) {
             }
-        }
-        if (++_processedRequestsCount == networkRequests.size) {
-            onFinalTaskResolved(_exitCode)
-            _exitCode = ExitCode.SUCCESS
+            if (++_processedRequestsCount == networkRequests.size) {
+                onFinalTaskResolved(_exitCode)
+            }
         }
     }
 
     fun fetchData() {
+        _exitCode = ExitCode.SUCCESS
         _processedRequestsCount = 0
         initNetworkRequests()
         networkRequests.forEach {
@@ -71,6 +73,7 @@ abstract class JSONWebParser : NetworkListener {
 
     fun abort() {
         _exitCode = ExitCode.ABORT
+        onFinalTaskResolved(_exitCode)
     }
 
     @Throws(JSONException::class)

--- a/app/src/main/res/layout/info_dialog.xml
+++ b/app/src/main/res/layout/info_dialog.xml
@@ -20,7 +20,10 @@
     android:orientation="vertical"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_gravity="center">
+    android:layout_gravity="center"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:clickable="true">
 
     <TextView
         android:layout_width="wrap_content"
@@ -30,7 +33,14 @@
         android:textStyle="bold"
         android:textSize="20dp"
         android:text="@string/dialog_loading"
-        android:id="@+id/dialogText"
-    />
+        android:id="@+id/dialogText"/>
+
+    <Button
+        android:id="@+id/cancelButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/cancel"
+        style="?android:attr/buttonBarButtonStyle"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,9 +87,9 @@
     <string name="route_drying_filter">Abtrocknung: mindestens</string>
 
     <!-- Toasts -->
-    <string name="successful_refresh">Aktualisierung erfolgreich</string>
+    <string name="refresh_successful">Aktualisierung erfolgreich</string>
     <string name="region_deleted">Gebiet gelöscht</string>
-    <string name="error_on_refresh">Fehler bei Aktualisierung</string>
+    <string name="refresh_failed">Aktualisierung fehlgeschlagen</string>
     <string name="refresh_aborted">Aktualisierung abgebrochen</string>
     <string name="ascends_refreshed">Begehungen aktualisiert</string>
     <string name="ascend_deleted">Begehung gelöscht</string>


### PR DESCRIPTION
Resolves #353 

Note: I've changed the update error handling so that a region update is immediately cancelled if an error occurs. However, for Update-All-Requests, I preserved the handling of continue updating the other regions and omit only the failed one.