### PR TITLE
Add view that lists all used libraries and their licenses

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,8 +170,6 @@ dependencies {
      * https://github.com/mikepenz/AboutLibraries
      */
     implementation "com.mikepenz:aboutlibraries-core:${aboutlibrariesVersion}"
-    //implementation "com.mikepenz:aboutlibraries-compose:${aboutlibrariesVersion}"
-    //implementation "com.mikepenz:aboutlibraries:${aboutlibrariesVersion}"
 }
 repositories {
     mavenCentral()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.github.triplet.play" version "3.6.0"
+    id "com.mikepenz.aboutlibraries.plugin"
 }
 apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
@@ -99,6 +100,11 @@ android {
     }
 }
 
+// https://github.com/mikepenz/AboutLibraries/blob/develop/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
+aboutLibraries {
+    prettyPrint = true
+}
+
 dependencies {
     // Room
     implementation fileTree(include: ["*.jar"], dir: "libs")
@@ -156,6 +162,15 @@ dependencies {
 
     // For introspection
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.0"
+
+    /*
+     * Listing all used libraries
+     *
+     * https://github.com/mikepenz/AboutLibraries
+     */
+    implementation "com.mikepenz:aboutlibraries-core:${aboutlibrariesVersion}"
+    //implementation "com.mikepenz:aboutlibraries-compose:${aboutlibrariesVersion}"
+    //implementation "com.mikepenz:aboutlibraries:${aboutlibrariesVersion}"
 }
 repositories {
     mavenCentral()

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,6 +103,7 @@ android {
 // https://github.com/mikepenz/AboutLibraries/blob/develop/plugin-build/plugin/src/main/kotlin/com/mikepenz/aboutlibraries/plugin/AboutLibrariesExtension.kt
 aboutLibraries {
     prettyPrint = true
+    configPath = "config/aboutLibraries"
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,23 +113,23 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.test:core-ktx:1.5.0"
 
-    def room_version = "2.4.3"
+    def roomVersion = "2.4.3"
 
-    implementation "androidx.room:room-runtime:$room_version"
-    kapt "androidx.room:room-compiler:$room_version"
+    implementation "androidx.room:room-runtime:$roomVersion"
+    kapt "androidx.room:room-compiler:$roomVersion"
 
     // optional - Kotlin Extensions and Coroutines support for Room
-    implementation "androidx.room:room-ktx:$room_version"
+    implementation "androidx.room:room-ktx:$roomVersion"
 
     // optional - RxJava support for Room
-    implementation "androidx.room:room-rxjava2:$room_version"
+    implementation "androidx.room:room-rxjava2:$roomVersion"
 
     // optional - Guava support for Room, including Optional and ListenableFuture
-    implementation "androidx.room:room-guava:$room_version"
+    implementation "androidx.room:room-guava:$roomVersion"
 
     implementation "net.sf.kxml:kxml2:2.3.0"
     implementation "com.caverock:androidsvg:1.4"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
 
     // Tests
@@ -149,9 +149,9 @@ dependencies {
      *
      * https://github.com/noties/Markwon
      */
-    def markwon_version = "4.6.2"
-    implementation "io.noties.markwon:core:$markwon_version"
-    implementation "io.noties.markwon:linkify:$markwon_version"
+    def markwonVersion = "4.6.2"
+    implementation "io.noties.markwon:core:$markwonVersion"
+    implementation "io.noties.markwon:linkify:$markwonVersion"
 
     /*
      * CSV library for tour book export

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,12 @@
             android:parentActivityName=".AboutActivity"
             android:theme="@style/AppTheme.ActionBar">
         </activity>
+        <activity
+            android:name=".AboutLibrariesActivity"
+            android:exported="false"
+            android:parentActivityName=".AboutActivity"
+            android:theme="@style/AppTheme.ActionBar">
+        </activity>
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/yacgroup/yacguide/AboutActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/AboutActivity.kt
@@ -44,6 +44,11 @@ class AboutActivity : BaseNavigationActivity() {
         _createEntry(getString(R.string.source_code_and_support), getString(R.string.github_url))
         _createEntry(getString(R.string.license), getString(R.string.license_url))
         _createEntry(
+            getString(R.string.open_source_libraries),
+            getString(R.string.open_source_libraries_details),
+            callback = { _showLibraries()}
+        )
+        _createEntry(
             getString(R.string.whats_new),
             WhatsNewInfo(this).getReleaseNotesUrl()
         )
@@ -81,5 +86,10 @@ class AboutActivity : BaseNavigationActivity() {
             }
             setNegativeButton()
         }.show()
+    }
+
+    private fun _showLibraries() {
+        val intent = Intent(this, AboutLibrariesActivity::class.java)
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/AboutActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/AboutActivity.kt
@@ -44,8 +44,7 @@ class AboutActivity : BaseNavigationActivity() {
         _createEntry(getString(R.string.source_code_and_support), getString(R.string.github_url))
         _createEntry(getString(R.string.license), getString(R.string.license_url))
         _createEntry(
-            getString(R.string.open_source_libraries),
-            getString(R.string.open_source_libraries_details),
+            getString(R.string.software_and_licenses),
             callback = { _showLibraries()}
         )
         _createEntry(
@@ -62,17 +61,15 @@ class AboutActivity : BaseNavigationActivity() {
             description: String = "",
             callback: (() -> Unit)? = null) {
         layoutInflater.inflate(R.layout.about_entry, null).let {
-            val contentAbout = findViewById<LinearLayout>(R.id.aboutContent)
             it.setOnClickListener { callback?.invoke() ?: _activityUtils.openUrl(description) }
             it.findViewById<TextView>(R.id.aboutEntryTitle).text = title
             it.findViewById<TextView>(R.id.aboutEntryDescription).text = description
-            contentAbout.addView(it)
+            findViewById<LinearLayout>(R.id.aboutContent).addView(it)
         }
     }
 
     private fun _showPrivacyPolicy() {
-        val intent = Intent(this, PrivacyPolicyActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(this, PrivacyPolicyActivity::class.java))
     }
 
     private fun _selectContactConcern() {
@@ -89,7 +86,6 @@ class AboutActivity : BaseNavigationActivity() {
     }
 
     private fun _showLibraries() {
-        val intent = Intent(this, AboutLibrariesActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(this, AboutLibrariesActivity::class.java))
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/AboutLibrariesActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/AboutLibrariesActivity.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Christian Sommer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/*
+ * NOTE:
+ * The library can automatically generate a view.
+ * However, it uses material design elements which makes things a bit inconsistent within
+ * this app. As soon as the app is migrated to material design, this and related code
+ * maybe become obsolete.
+ */
+
+package com.yacgroup.yacguide
+
+import android.os.Bundle
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.mikepenz.aboutlibraries.Libs
+import com.mikepenz.aboutlibraries.entity.Library
+import com.yacgroup.yacguide.utils.ActivityUtils
+
+class AboutLibrariesActivity : AppCompatActivity () {
+
+    private lateinit var _activityUtils: ActivityUtils
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        _activityUtils = ActivityUtils(this)
+        setTitle(R.string.open_source_libraries)
+        setContentView(R.layout.activity_about_libraries)
+        _displaycontent()
+    }
+
+    private fun _displaycontent() {
+        // The resource JSON file is automatically generated
+        // by the Gradle plugin com.mikepenz.aboutlibraries.plugin
+        val jsonStr = resources.openRawResource(R.raw.aboutlibraries)
+            .bufferedReader().use  { it.readText() }
+        val libs = Libs.Builder()
+            .withJson(jsonStr)
+            .build()
+        for (lib in libs.libraries.sortedBy { it.uniqueId }) {
+            _createEntry(lib)
+        }
+    }
+
+    private fun _createEntry(lib: Library) {
+        layoutInflater.inflate(R.layout.about_libraries_entry, null).let {
+            val content = findViewById<LinearLayout>(R.id.aboutLibrariesContent)
+            it.setOnClickListener { _activityUtils.openUrl(lib.website.orEmpty()) }
+            it.findViewById<TextView>(R.id.aboutLibrariesName).text = lib.uniqueId
+            it.findViewById<TextView>(R.id.aboutLibrariesVersion).text = lib.artifactVersion
+            val licenses= lib.licenses.joinToString(
+                separator=", ",
+                transform = { license -> license.name }
+            )
+            it.findViewById<TextView>(R.id.aboutLibrariesLicenses).text = licenses
+            content.addView(it)
+        }
+    }
+}

--- a/app/src/main/java/com/yacgroup/yacguide/AboutLibrariesActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/AboutLibrariesActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Christian Sommer
+ * Copyright (C) 2023 Christian Sommer
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@
  * The library can automatically generate a view.
  * However, it uses material design elements which makes things a bit inconsistent within
  * this app. As soon as the app is migrated to material design, this and related code
- * maybe become obsolete.
+ * may become obsolete.
  */
 
 package com.yacgroup.yacguide
@@ -33,19 +33,19 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.entity.Library
 import com.yacgroup.yacguide.utils.ActivityUtils
 
-class AboutLibrariesActivity : AppCompatActivity () {
+class AboutLibrariesActivity : AppCompatActivity() {
 
     private lateinit var _activityUtils: ActivityUtils
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         _activityUtils = ActivityUtils(this)
-        setTitle(R.string.open_source_libraries)
+        setTitle(R.string.software_and_licenses)
         setContentView(R.layout.activity_about_libraries)
-        _displaycontent()
+        _displayContent()
     }
 
-    private fun _displaycontent() {
+    private fun _displayContent() {
         // The resource JSON file is automatically generated
         // by the Gradle plugin com.mikepenz.aboutlibraries.plugin
         val jsonStr = resources.openRawResource(R.raw.aboutlibraries)
@@ -53,23 +53,22 @@ class AboutLibrariesActivity : AppCompatActivity () {
         val libs = Libs.Builder()
             .withJson(jsonStr)
             .build()
-        for (lib in libs.libraries.sortedBy { it.uniqueId }) {
-            _createEntry(lib)
+        libs.libraries.sortedBy { it.uniqueId }.forEach {
+            _createEntry(it)
         }
     }
 
     private fun _createEntry(lib: Library) {
         layoutInflater.inflate(R.layout.about_libraries_entry, null).let {
-            val content = findViewById<LinearLayout>(R.id.aboutLibrariesContent)
             it.setOnClickListener { _activityUtils.openUrl(lib.website.orEmpty()) }
             it.findViewById<TextView>(R.id.aboutLibrariesName).text = lib.uniqueId
             it.findViewById<TextView>(R.id.aboutLibrariesVersion).text = lib.artifactVersion
-            val licenses= lib.licenses.joinToString(
-                separator=", ",
+            val licenses = lib.licenses.joinToString(
+                separator = ", ",
                 transform = { license -> license.name }
             )
             it.findViewById<TextView>(R.id.aboutLibrariesLicenses).text = licenses
-            content.addView(it)
+            findViewById<LinearLayout>(R.id.aboutLibrariesContent).addView(it)
         }
     }
 }

--- a/app/src/main/java/com/yacgroup/yacguide/PrivacyPolicyActivity.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/PrivacyPolicyActivity.kt
@@ -31,7 +31,6 @@ class PrivacyPolicyActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setTitle(R.string.privacy_policy)
         setContentView(R.layout.activity_privacy_policy)
-        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         _displayContent()
     }
 

--- a/app/src/main/res/layout/about_entry.xml
+++ b/app/src/main/res/layout/about_entry.xml
@@ -28,7 +28,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        android:layout_marginStart="20dp"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:textAlignment="textStart"
         android:textSize="16sp"
         android:textColor="?android:textColorPrimary"/>
@@ -37,16 +37,14 @@
         android:id="@+id/aboutEntryDescription"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:textAlignment="textStart"
         android:textSize="14sp"
         android:textColor="?android:textColorSecondary"/>
 
     <View
         android:id="@+id/divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
         android:layout_marginTop="10dp"
-        android:background="?android:attr/listDivider"/>
+        style="@style/ThinDivider"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/about_libraries_entry.xml
+++ b/app/src/main/res/layout/about_libraries_entry.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright (C) 2022 Christian Sommer
+  Copyright (C) 2023 Christian Sommer
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -27,8 +27,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
-        android:layout_marginStart="20dp"
-        android:layout_marginEnd="20dp"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
         android:textAlignment="textStart"
         android:textSize="16sp"
         android:textColor="?android:textColorPrimary"/>
@@ -44,7 +44,7 @@
             android:layout_weight="0.8"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:layout_marginStart="20dp"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
             android:textAlignment="textStart"
             android:textSize="14sp"
             android:textColor="?android:textColorSecondary"/>
@@ -55,7 +55,7 @@
             android:layout_weight="0.2"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:layout_marginEnd="20dp"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:textAlignment="textEnd"
             android:textSize="14sp"
             android:textColor="?android:textColorSecondary"/>
@@ -63,9 +63,7 @@
 
     <View
         android:id="@+id/divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
         android:layout_marginTop="10dp"
-        android:background="?android:attr/listDivider"/>
+        style="@style/ThinDivider"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/about_libraries_entry.xml
+++ b/app/src/main/res/layout/about_libraries_entry.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (C) 2022 Christian Sommer
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:foreground="?android:attr/selectableItemBackground">
+
+    <TextView
+        android:id="@+id/aboutLibrariesName"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginEnd="20dp"
+        android:textAlignment="textStart"
+        android:textSize="16sp"
+        android:textColor="?android:textColorPrimary"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/aboutLibrariesLicenses"
+            android:layout_width="0dp"
+            android:layout_weight="0.8"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:layout_marginStart="20dp"
+            android:textAlignment="textStart"
+            android:textSize="14sp"
+            android:textColor="?android:textColorSecondary"/>
+
+        <TextView
+            android:id="@+id/aboutLibrariesVersion"
+            android:layout_width="0dp"
+            android:layout_weight="0.2"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="20dp"
+            android:textAlignment="textEnd"
+            android:textSize="14sp"
+            android:textColor="?android:textColorSecondary"/>
+    </LinearLayout>
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="10dp"
+        android:background="?android:attr/listDivider"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_about_libraries.xml
+++ b/app/src/main/res/layout/activity_about_libraries.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  Copyright (C) 2022 Christian Sommer
+  Copyright (C) 2023 Christian Sommer
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/app/src/main/res/layout/activity_about_libraries.xml
+++ b/app/src/main/res/layout/activity_about_libraries.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (C) 2022 Christian Sommer
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/aboutLibrariesContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"/>
+
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,8 +60,7 @@
     <string name="data_src">Datenbezugsquelle</string>
     <string name="privacy_policy">Datenschutzerklärung</string>
     <string name="license">Lizenz</string>
-    <string name="open_source_libraries">Bibliotheken und Lizenzen</string>
-    <string name="open_source_libraries_details">Bibliotheken die diese App möglich machen.</string>
+    <string name="software_and_licenses">Externe Software und Lizenzen</string>
     <string name="version">Version</string>
     <string name="contact">Kontakt</string>
     <string name="contact_details">Generelles Feedback und Fehler melden</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="data_src">Datenbezugsquelle</string>
     <string name="privacy_policy">Datenschutzerklärung</string>
     <string name="license">Lizenz</string>
+    <string name="open_source_libraries">Bibliotheken und Lizenzen</string>
+    <string name="open_source_libraries_details">Bibliotheken die diese App möglich machen.</string>
     <string name="version">Version</string>
     <string name="contact">Kontakt</string>
     <string name="contact_details">Generelles Feedback und Fehler melden</string>

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext.kotlin_version = "1.7.20"
+    ext.aboutlibrariesVersion = "10.5.2"
 
     repositories {
         google()
@@ -15,6 +16,10 @@ buildscript {
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
+}
+
+plugins {
+    id "com.mikepenz.aboutlibraries.plugin" version "${aboutlibrariesVersion}" apply false
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = "1.7.20"
+    ext.kotlinVersion = "1.7.20"
     ext.aboutlibrariesVersion = "10.5.2"
 
     repositories {
@@ -10,7 +10,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.8.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/config/aboutLibraries/libraries/lib_apache_commons_csv.json
+++ b/config/aboutLibraries/libraries/lib_apache_commons_csv.json
@@ -1,0 +1,6 @@
+{
+    "uniqueId": "org.apache.commons:commons-csv",
+    "licenses": [
+        "Apache-2.0"
+    ]
+}


### PR DESCRIPTION
Fixes #155 

For some reason, the license for the [Apache Commons CSV](https://commons.apache.org/proper/commons-csv/) library is empty. It is under clarification in issue https://github.com/mikepenz/AboutLibraries/issues/827. Since the information are generated automatically during each build, it should not be a blocker to merge this issue.