### PR TITLE
Make UpdateDialog always-present again

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
@@ -44,8 +44,11 @@ class UpdateHandler(private val _activity: AppCompatActivity,
     init {
         _jsonParser.listener = this
 
-        _updateDialog = Dialog(_activity)
-        _updateDialog.setContentView(R.layout.info_dialog)
+        _updateDialog = Dialog(_activity).apply {
+            setContentView(R.layout.info_dialog)
+            setCancelable(false)
+            setCanceledOnTouchOutside(false)
+        }
         _updateDialog.findViewById<Button>(R.id.cancelButton).setOnClickListener {
             abort()
         }


### PR DESCRIPTION
For #353 I have accidentally removed the update dialog's behavior that it is always in the foreground even when the user touches outside of it or presses the back button.
I have re-added it in this PR.