### PR TITLE
Added queue for network requests

### DIFF
--- a/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/UpdateHandler.kt
@@ -64,16 +64,18 @@ class UpdateHandler(private val _activity: AppCompatActivity,
     }
 
     override fun onUpdateFinished(exitCode: ExitCode) {
-        if (exitCode == ExitCode.ABORT) {
-            _exitCode = ExitCode.ABORT
-            finish()
-        } else {
-            if (exitCode == ExitCode.ERROR) {
-                _exitCode = ExitCode.ERROR
-            }
-            _onUpdateFinished()
-            if (!_isRecurringUpdate) {
+        _activity.runOnUiThread {
+            if (exitCode == ExitCode.ABORT) {
+                _exitCode = ExitCode.ABORT
                 finish()
+            } else {
+                if (exitCode == ExitCode.ERROR) {
+                    _exitCode = ExitCode.ERROR
+                }
+                _onUpdateFinished()
+                if (!_isRecurringUpdate) {
+                    finish()
+                }
             }
         }
     }

--- a/app/src/main/java/com/yacgroup/yacguide/network/CountryAndRegionParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/CountryAndRegionParser.kt
@@ -23,7 +23,6 @@ import com.yacgroup.yacguide.database.DatabaseWrapper
 import com.yacgroup.yacguide.database.Region
 import com.yacgroup.yacguide.utils.NetworkUtils
 import com.yacgroup.yacguide.utils.ParserUtils
-
 import org.json.JSONArray
 import org.json.JSONException
 import java.lang.RuntimeException
@@ -69,7 +68,7 @@ class CountryAndRegionParser(private val _db: DatabaseWrapper) : JSONWebParser()
             type = RequestType.REGION_DATA,
             url = "${baseUrl}jsongebiet.php?app=yacguide&land=${NetworkUtils.encodeString2Url(countryName)}")
         networkRequests.add(request)
-        NetworkTask(request, this).execute()
+        NetworkTask(request, networkScope, this).execute()
     }
 
     private fun _parseRegions(json: String, countryName: String) {

--- a/app/src/main/java/com/yacgroup/yacguide/network/NetworkListener.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/NetworkListener.kt
@@ -17,8 +17,12 @@
 
 package com.yacgroup.yacguide.network
 
+data class NetworkAnswer(
+    val request: NetworkRequest,
+    val answer: String
+)
+
 interface NetworkListener {
 
-    fun onNetworkTaskResolved(request: NetworkRequest, result: String)
-
+    fun onNetworkTaskResolved(networkAnswer: NetworkAnswer)
 }

--- a/app/src/main/java/com/yacgroup/yacguide/network/NetworkRequest.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/NetworkRequest.kt
@@ -29,7 +29,7 @@ enum class RequestType {
     SECTOR_COMMENTS
 }
 
-class NetworkRequest(
+data class NetworkRequest(
     val uid: ClimbingObjectUId,
     val type: RequestType,
     val url: String

--- a/app/src/main/java/com/yacgroup/yacguide/network/NetworkTask.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/NetworkTask.kt
@@ -21,21 +21,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
-import kotlin.coroutines.CoroutineContext
 
 class NetworkTask(private val _request: NetworkRequest,
-                  private val _listener: NetworkListener) : CoroutineScope {
+                  private val _scope: CoroutineScope,
+                  private val _listener: NetworkListener) {
 
-    override val coroutineContext: CoroutineContext
-        get() = Dispatchers.Main
-
-    fun execute() = launch {
+    fun execute() = _scope.launch {
         val result = _performNetworkRequest()
-        _listener.onNetworkTaskResolved(_request, result)
+        _listener.onNetworkTaskResolved(NetworkAnswer(_request, result))
     }
 
     private suspend fun _performNetworkRequest(): String = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/network/SectorParser.kt
@@ -25,7 +25,6 @@ import com.yacgroup.yacguide.database.comment.RouteComment
 import com.yacgroup.yacguide.database.comment.SectorComment
 import com.yacgroup.yacguide.utils.AscendStyle
 import com.yacgroup.yacguide.utils.ParserUtils
-
 import org.json.JSONArray
 import org.json.JSONException
 import java.lang.RuntimeException
@@ -164,7 +163,7 @@ class SectorParser(private val _db: DatabaseWrapper) : JSONWebParser() {
         )
         networkRequests.addAll(requests)
         requests.forEach {
-            NetworkTask(it, this).execute()
+            NetworkTask(it, networkScope, this).execute()
         }
     }
 


### PR DESCRIPTION
Resolves #309

Up to now, json parsing during updating, had been done on the main thread. That's why the percentage display and the abort button were quite slow in response.
The new approach uses a bunch of coroutines (Coroutine = sth. like a lightweight thread):
1. One coroutine per network request pushing its result to a thread-safe queue
2. One coroutine for the worker method that polls and processes this queue
All those are decoupled from the main thread, so that UI works smoothly.