### PR TITLE
Update chart library to be able to configure axis label count

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ dependencies {
 
     implementation 'net.sf.kxml:kxml2:2.3.0'
     implementation 'com.caverock:androidsvg:1.4'
-    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
+    implementation "com.github.AppDevNext:AndroidChart:3.1.0.25"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
 

--- a/app/src/main/java/com/yacgroup/yacguide/list_adapters/StatisticsViewAdapter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/list_adapters/StatisticsViewAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Axel Paetzold
+ * Copyright (C) 2023, 2025 Axel Paetzold
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,6 +60,7 @@ class StatisticsViewAdapter(private val _baseColor: Color) : ListAdapter<Statist
                 with(xAxis) {
                     valueFormatter = AxisFormatter(stat.data.keys.toList())
                     xAxis.setDrawGridLines(false)
+                    xAxis.axisMaxLabels = stat.data.size // Allow more labels than the default limit (25)
                     xAxis.labelCount = stat.data.size // Do not display more than the number of x values as labels
                     xAxis.granularity = 1f // Do not duplicate labels on zooming to match labelCount
                 }

--- a/app/src/main/java/com/yacgroup/yacguide/utils/ChartFormatter.kt
+++ b/app/src/main/java/com/yacgroup/yacguide/utils/ChartFormatter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Axel Paetzold
+ * Copyright (C) 2023, 2025 Axel Paetzold
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,11 +18,14 @@
 package com.yacgroup.yacguide.utils
 
 import com.github.mikephil.charting.components.AxisBase
-import com.github.mikephil.charting.formatter.ValueFormatter
+import com.github.mikephil.charting.data.Entry
+import com.github.mikephil.charting.formatter.IAxisValueFormatter
+import com.github.mikephil.charting.formatter.IValueFormatter
+import com.github.mikephil.charting.utils.ViewPortHandler
 
-class AxisFormatter(private val _labels: List<String>) : ValueFormatter() {
+class AxisFormatter(private val _labels: List<String>) : IAxisValueFormatter {
     // This class provides custom axis labels different from indices
-    override fun getAxisLabel(value: Float, axis: AxisBase?): String {
+    override fun getFormattedValue(value: Float, axis: AxisBase?): String {
         return try {
             _labels[value.toInt()]
         } catch (e: IndexOutOfBoundsException) {
@@ -31,9 +34,14 @@ class AxisFormatter(private val _labels: List<String>) : ValueFormatter() {
     }
 }
 
-class IntValueFormatter : ValueFormatter() {
+class IntValueFormatter : IValueFormatter {
 
-    override fun getFormattedValue(value: Float): String {
+    override fun getFormattedValue(
+        value: Float,
+        entry: Entry?,
+        dataSetIndex: Int,
+        viewPortHandler: ViewPortHandler?
+    ): String {
         return if (value > 0) value.toInt().toString() else ""
     }
 }

--- a/app/src/test/java/com/yacgroup/yacguide/utils/ChartFormatterTest.kt
+++ b/app/src/test/java/com/yacgroup/yacguide/utils/ChartFormatterTest.kt
@@ -26,7 +26,7 @@ internal class ChartFormatterTest {
     @Test
     fun axisFormatter_getAxisLabel_invalidIndex_returnsEmptyString() {
         val formatter = AxisFormatter(listOf("Label1", "Label2"))
-        assertTrue(formatter.getAxisLabel(100f, null) == "")
+        assertTrue(formatter.getFormattedValue(100f, null) == "")
     }
 
     @Test
@@ -34,19 +34,19 @@ internal class ChartFormatterTest {
         val labelList = listOf("Label1", "Label2", "Label3")
         val formatter = AxisFormatter(labelList)
         labelList.forEachIndexed { idx, label ->
-            assertEquals(label, formatter.getAxisLabel(idx.toFloat(), null))
+            assertEquals(label, formatter.getFormattedValue(idx.toFloat(), null))
         }
     }
 
     @Test
     fun intValueFormatter_getFormattedValue_valueIsZeroOrLower_ReturnsEmptyString() {
-        assertTrue(IntValueFormatter().getFormattedValue(0f) == "")
-        assertTrue(IntValueFormatter().getFormattedValue(-3f) == "")
+        assertTrue(IntValueFormatter().getFormattedValue(0f, null, 0, null) == "")
+        assertTrue(IntValueFormatter().getFormattedValue(-3f, null , 0, null) == "")
     }
 
     @Test
     fun intValueFormatter_getFormattedValue_valueIsGreaterThanZero_ReturnsAccordingIntValueAsString() {
         val value = 3.5f
-        assertTrue(value.toInt().toString() == IntValueFormatter().getFormattedValue(value))
+        assertTrue(value.toInt().toString() == IntValueFormatter().getFormattedValue(value, null, 0, null))
     }
 }


### PR DESCRIPTION
This PR fixes the issue that we could only have up to 25 axis labels in our statistic graphs.

I have found an actively maintained fork of our chart library that allows configuration of that limit, so I have replaced the original lib by this fork and configured the upper limit of axis labels before displaying it.